### PR TITLE
build: add musl targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,18 @@ jobs:
             os: ubuntu-latest
             cross: false
             deb: false
+          - prefix: x86_64-linux
+            target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: false
+            deb: false
           - prefix: i686-linux
             target: i686-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+            deb: true
+          - prefix: i686-linux
+            target: i686-unknown-linux-musl
             os: ubuntu-latest
             cross: true
             deb: true


### PR DESCRIPTION
The `x86_64-unknown-linux-gnu` target requires GLIBC version >= 2.32, which cannot be run on old Linux distributions. Some rust utilities, e.g. [ripgrep](https://github.com/BurntSushi/ripgrep), [fd](https://github.com/sharkdp/fd),  will build `x86_64-unknown-linux-musl` target to get rid of the dependencies of GLIBC.