### PR TITLE
feat: add completion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,10 @@ jobs:
           files="example.toml THIRD_PARTY_LICENSES.md LICENSE README.md"
           $GITHUB_WORKSPACE/scripts/package_build \
             "example.toml THIRD_PARTY_LICENSES.md LICENSE README.md" \
+            "contrib/completion/tinty.bash" \
+            "contrib/completion/tinty.zsh" \
+            "contrib/completion/tinty.fish" \
+            "contrib/completion/tinty.ps1" \
             "${{ matrix.target }}" \
             "$GITHUB_WORKSPACE" \
             "${{ steps.cargo_version.outputs.value }}"
@@ -209,6 +213,7 @@ jobs:
 
   publish:
     needs: release
+    runs-on: ubuntu-latest
     steps:
       - name: Publish to crates.io
         if: github.ref == 'refs/heads/main'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -97,10 +97,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.4.7"
+name = "clap_complete"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "pathdiff",
+ "shlex",
+ "unicode-xid",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -110,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -175,9 +189,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex_color"
@@ -206,6 +220,15 @@ checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -242,6 +265,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -378,6 +407,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strip-ansi-escapes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -429,6 +464,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "dirs",
  "hex_color",
  "serde",
@@ -510,6 +546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +599,28 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.75"
 clap = { version = "4.4.8", features = ["derive"] }
+clap_complete = { version = "4.5.2", features = ["unstable-dynamic"] }
 dirs = "5.0.1"
 hex_color = "3.0.0"
 serde = { version = "1.0.196", features = ["derive"] }

--- a/contrib/completion/tinty.bash
+++ b/contrib/completion/tinty.bash
@@ -101,7 +101,7 @@ _tinty() {
             return 0
             ;;
         tinty__apply)
-            opts="-c -d -h --config --data-dir --help <scheme_name>"
+            opts="-c -d -h --config --data-dir --help $($1 list)"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -120,6 +120,10 @@ _tinty() {
                     return 0
                     ;;
                 -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                base*)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -287,7 +291,7 @@ _tinty() {
             return 0
             ;;
         tinty__info)
-            opts="-c -d -h --config --data-dir --help [scheme_name]"
+            opts="-c -d -h --config --data-dir --help $($1 list)"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -306,6 +310,10 @@ _tinty() {
                     return 0
                     ;;
                 -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                base*)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/contrib/completion/tinty.bash
+++ b/contrib/completion/tinty.bash
@@ -1,0 +1,446 @@
+_tinty() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cmd=""
+    opts=""
+
+    for i in ${COMP_WORDS[@]}
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="tinty"
+                ;;
+            tinty,apply)
+                cmd="tinty__apply"
+                ;;
+            tinty,current)
+                cmd="tinty__current"
+                ;;
+            tinty,help)
+                cmd="tinty__help"
+                ;;
+            tinty,info)
+                cmd="tinty__info"
+                ;;
+            tinty,init)
+                cmd="tinty__init"
+                ;;
+            tinty,install)
+                cmd="tinty__install"
+                ;;
+            tinty,list)
+                cmd="tinty__list"
+                ;;
+            tinty,update)
+                cmd="tinty__update"
+                ;;
+            tinty__help,apply)
+                cmd="tinty__help__apply"
+                ;;
+            tinty__help,current)
+                cmd="tinty__help__current"
+                ;;
+            tinty__help,help)
+                cmd="tinty__help__help"
+                ;;
+            tinty__help,info)
+                cmd="tinty__help__info"
+                ;;
+            tinty__help,init)
+                cmd="tinty__help__init"
+                ;;
+            tinty__help,install)
+                cmd="tinty__help__install"
+                ;;
+            tinty__help,list)
+                cmd="tinty__help__list"
+                ;;
+            tinty__help,update)
+                cmd="tinty__help__update"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        tinty)
+            opts="-c -d -h -V --config --data-dir --generate-completion --help --version current info init list apply install update help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --generate-completion)
+                    COMPREPLY=($(compgen -W "bash elvish fish powershell zsh" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__apply)
+            opts="-c -d -h --config --data-dir --help <scheme_name>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__current)
+            opts="-c -d -h --config --data-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help)
+            opts="current info init list apply install update help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help__apply)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help__current)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help__info)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help__init)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help__install)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__help__update)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__info)
+            opts="-c -d -h --config --data-dir --help [scheme_name]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__init)
+            opts="-c -d -h --config --data-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__install)
+            opts="-c -d -h --config --data-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__list)
+            opts="-c -d -h --config --data-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        tinty__update)
+            opts="-c -d -h --config --data-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _tinty -o nosort -o bashdefault -o default tinty
+else
+    complete -F _tinty -o bashdefault -o default tinty
+fi

--- a/contrib/completion/tinty.fish
+++ b/contrib/completion/tinty.fish
@@ -1,0 +1,42 @@
+complete -c tinty -n "__fish_use_subcommand" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_use_subcommand" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_use_subcommand" -l generate-completion -d 'Generate completion scripts' -r -f -a "{bash	'',elvish	'',fish	'',powershell	'',zsh	''}"
+complete -c tinty -n "__fish_use_subcommand" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_use_subcommand" -s V -l version -d 'Print version'
+complete -c tinty -n "__fish_use_subcommand" -f -a "current" -d 'Prints the last scheme name applied'
+complete -c tinty -n "__fish_use_subcommand" -f -a "info" -d 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)'
+complete -c tinty -n "__fish_use_subcommand" -f -a "init" -d 'Initializes with the exising config. Used to Initialize exising theme for when your shell starts up'
+complete -c tinty -n "__fish_use_subcommand" -f -a "list" -d 'Lists available schemes'
+complete -c tinty -n "__fish_use_subcommand" -f -a "apply" -d 'Applies a theme based on the chosen scheme'
+complete -c tinty -n "__fish_use_subcommand" -f -a "install" -d 'Install the environment needed for tinty'
+complete -c tinty -n "__fish_use_subcommand" -f -a "update" -d 'Update to the latest themes'
+complete -c tinty -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c tinty -n "__fish_seen_subcommand_from current" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_seen_subcommand_from current" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_seen_subcommand_from current" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_seen_subcommand_from info" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_seen_subcommand_from info" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_seen_subcommand_from info" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_seen_subcommand_from init" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_seen_subcommand_from init" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_seen_subcommand_from init" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_seen_subcommand_from list" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_seen_subcommand_from list" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_seen_subcommand_from list" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_seen_subcommand_from apply" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_seen_subcommand_from apply" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_seen_subcommand_from apply" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_seen_subcommand_from install" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_seen_subcommand_from install" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_seen_subcommand_from install" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_seen_subcommand_from update" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_seen_subcommand_from update" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_seen_subcommand_from update" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from current; and not __fish_seen_subcommand_from info; and not __fish_seen_subcommand_from init; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from apply; and not __fish_seen_subcommand_from install; and not __fish_seen_subcommand_from update; and not __fish_seen_subcommand_from help" -f -a "current" -d 'Prints the last scheme name applied'
+complete -c tinty -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from current; and not __fish_seen_subcommand_from info; and not __fish_seen_subcommand_from init; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from apply; and not __fish_seen_subcommand_from install; and not __fish_seen_subcommand_from update; and not __fish_seen_subcommand_from help" -f -a "info" -d 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)'
+complete -c tinty -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from current; and not __fish_seen_subcommand_from info; and not __fish_seen_subcommand_from init; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from apply; and not __fish_seen_subcommand_from install; and not __fish_seen_subcommand_from update; and not __fish_seen_subcommand_from help" -f -a "init" -d 'Initializes with the exising config. Used to Initialize exising theme for when your shell starts up'
+complete -c tinty -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from current; and not __fish_seen_subcommand_from info; and not __fish_seen_subcommand_from init; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from apply; and not __fish_seen_subcommand_from install; and not __fish_seen_subcommand_from update; and not __fish_seen_subcommand_from help" -f -a "list" -d 'Lists available schemes'
+complete -c tinty -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from current; and not __fish_seen_subcommand_from info; and not __fish_seen_subcommand_from init; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from apply; and not __fish_seen_subcommand_from install; and not __fish_seen_subcommand_from update; and not __fish_seen_subcommand_from help" -f -a "apply" -d 'Applies a theme based on the chosen scheme'
+complete -c tinty -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from current; and not __fish_seen_subcommand_from info; and not __fish_seen_subcommand_from init; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from apply; and not __fish_seen_subcommand_from install; and not __fish_seen_subcommand_from update; and not __fish_seen_subcommand_from help" -f -a "install" -d 'Install the environment needed for tinty'
+complete -c tinty -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from current; and not __fish_seen_subcommand_from info; and not __fish_seen_subcommand_from init; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from apply; and not __fish_seen_subcommand_from install; and not __fish_seen_subcommand_from update; and not __fish_seen_subcommand_from help" -f -a "update" -d 'Update to the latest themes'
+complete -c tinty -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from current; and not __fish_seen_subcommand_from info; and not __fish_seen_subcommand_from init; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from apply; and not __fish_seen_subcommand_from install; and not __fish_seen_subcommand_from update; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/contrib/completion/tinty.ps1
+++ b/contrib/completion/tinty.ps1
@@ -1,0 +1,145 @@
+
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+Register-ArgumentCompleter -Native -CommandName 'tinty' -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commandElements = $commandAst.CommandElements
+    $command = @(
+        'tinty'
+        for ($i = 1; $i -lt $commandElements.Count; $i++) {
+            $element = $commandElements[$i]
+            if ($element -isnot [StringConstantExpressionAst] -or
+                $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                $element.Value.StartsWith('-') -or
+                $element.Value -eq $wordToComplete) {
+                break
+        }
+        $element.Value
+    }) -join ';'
+
+    $completions = @(switch ($command) {
+        'tinty' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--generate-completion', 'generate-completion', [CompletionResultType]::ParameterName, 'Generate completion scripts')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', 'V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('current', 'current', [CompletionResultType]::ParameterValue, 'Prints the last scheme name applied')
+            [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)')
+            [CompletionResult]::new('init', 'init', [CompletionResultType]::ParameterValue, 'Initializes with the exising config. Used to Initialize exising theme for when your shell starts up')
+            [CompletionResult]::new('list', 'list', [CompletionResultType]::ParameterValue, 'Lists available schemes')
+            [CompletionResult]::new('apply', 'apply', [CompletionResultType]::ParameterValue, 'Applies a theme based on the chosen scheme')
+            [CompletionResult]::new('install', 'install', [CompletionResultType]::ParameterValue, 'Install the environment needed for tinty')
+            [CompletionResult]::new('update', 'update', [CompletionResultType]::ParameterValue, 'Update to the latest themes')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
+            break
+        }
+        'tinty;current' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'tinty;info' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'tinty;init' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'tinty;list' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'tinty;apply' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'tinty;install' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'tinty;update' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Optional path to the tinty config.toml file')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Optional path to the tinty data directory')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            break
+        }
+        'tinty;help' {
+            [CompletionResult]::new('current', 'current', [CompletionResultType]::ParameterValue, 'Prints the last scheme name applied')
+            [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)')
+            [CompletionResult]::new('init', 'init', [CompletionResultType]::ParameterValue, 'Initializes with the exising config. Used to Initialize exising theme for when your shell starts up')
+            [CompletionResult]::new('list', 'list', [CompletionResultType]::ParameterValue, 'Lists available schemes')
+            [CompletionResult]::new('apply', 'apply', [CompletionResultType]::ParameterValue, 'Applies a theme based on the chosen scheme')
+            [CompletionResult]::new('install', 'install', [CompletionResultType]::ParameterValue, 'Install the environment needed for tinty')
+            [CompletionResult]::new('update', 'update', [CompletionResultType]::ParameterValue, 'Update to the latest themes')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
+            break
+        }
+        'tinty;help;current' {
+            break
+        }
+        'tinty;help;info' {
+            break
+        }
+        'tinty;help;init' {
+            break
+        }
+        'tinty;help;list' {
+            break
+        }
+        'tinty;help;apply' {
+            break
+        }
+        'tinty;help;install' {
+            break
+        }
+        'tinty;help;update' {
+            break
+        }
+        'tinty;help;help' {
+            break
+        }
+    })
+
+    $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
+        Sort-Object -Property ListItemText
+}

--- a/contrib/completion/tinty.zsh
+++ b/contrib/completion/tinty.zsh
@@ -1,0 +1,269 @@
+#compdef tinty
+
+autoload -U is-at-least
+
+_tinty() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" \
+'-c+[Optional path to the tinty config.toml file]:FILE: ' \
+'--config=[Optional path to the tinty config.toml file]:FILE: ' \
+'-d+[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--generate-completion=[Generate completion scripts]:SHELL:(bash elvish fish powershell zsh)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_tinty_commands" \
+"*::: :->tinty" \
+&& ret=0
+    case $state in
+    (tinty)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:tinty-command-$line[1]:"
+        case $line[1] in
+            (current)
+_arguments "${_arguments_options[@]}" \
+'-c+[Optional path to the tinty config.toml file]:FILE: ' \
+'--config=[Optional path to the tinty config.toml file]:FILE: ' \
+'-d+[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(info)
+_arguments "${_arguments_options[@]}" \
+'-c+[Optional path to the tinty config.toml file]:FILE: ' \
+'--config=[Optional path to the tinty config.toml file]:FILE: ' \
+'-d+[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+'::scheme_name -- The scheme you want to get information about:' \
+&& ret=0
+;;
+(init)
+_arguments "${_arguments_options[@]}" \
+'-c+[Optional path to the tinty config.toml file]:FILE: ' \
+'--config=[Optional path to the tinty config.toml file]:FILE: ' \
+'-d+[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(list)
+_arguments "${_arguments_options[@]}" \
+'-c+[Optional path to the tinty config.toml file]:FILE: ' \
+'--config=[Optional path to the tinty config.toml file]:FILE: ' \
+'-d+[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(apply)
+_arguments "${_arguments_options[@]}" \
+'-c+[Optional path to the tinty config.toml file]:FILE: ' \
+'--config=[Optional path to the tinty config.toml file]:FILE: ' \
+'-d+[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+':scheme_name -- The scheme you want to apply:' \
+&& ret=0
+;;
+(install)
+_arguments "${_arguments_options[@]}" \
+'-c+[Optional path to the tinty config.toml file]:FILE: ' \
+'--config=[Optional path to the tinty config.toml file]:FILE: ' \
+'-d+[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" \
+'-c+[Optional path to the tinty config.toml file]:FILE: ' \
+'--config=[Optional path to the tinty config.toml file]:FILE: ' \
+'-d+[Optional path to the tinty data directory]:DIRECTORY: ' \
+'--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" \
+":: :_tinty__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:tinty-help-command-$line[1]:"
+        case $line[1] in
+            (current)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+(info)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+(init)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+(list)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+(apply)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+(install)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_tinty_commands] )) ||
+_tinty_commands() {
+    local commands; commands=(
+'current:Prints the last scheme name applied' \
+'info:Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg\: tinty info base16-mocha)' \
+'init:Initializes with the exising config. Used to Initialize exising theme for when your shell starts up' \
+'list:Lists available schemes' \
+'apply:Applies a theme based on the chosen scheme' \
+'install:Install the environment needed for tinty' \
+'update:Update to the latest themes' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'tinty commands' commands "$@"
+}
+(( $+functions[_tinty__apply_commands] )) ||
+_tinty__apply_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty apply commands' commands "$@"
+}
+(( $+functions[_tinty__help__apply_commands] )) ||
+_tinty__help__apply_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty help apply commands' commands "$@"
+}
+(( $+functions[_tinty__current_commands] )) ||
+_tinty__current_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty current commands' commands "$@"
+}
+(( $+functions[_tinty__help__current_commands] )) ||
+_tinty__help__current_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty help current commands' commands "$@"
+}
+(( $+functions[_tinty__help_commands] )) ||
+_tinty__help_commands() {
+    local commands; commands=(
+'current:Prints the last scheme name applied' \
+'info:Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg\: tinty info base16-mocha)' \
+'init:Initializes with the exising config. Used to Initialize exising theme for when your shell starts up' \
+'list:Lists available schemes' \
+'apply:Applies a theme based on the chosen scheme' \
+'install:Install the environment needed for tinty' \
+'update:Update to the latest themes' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'tinty help commands' commands "$@"
+}
+(( $+functions[_tinty__help__help_commands] )) ||
+_tinty__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty help help commands' commands "$@"
+}
+(( $+functions[_tinty__help__info_commands] )) ||
+_tinty__help__info_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty help info commands' commands "$@"
+}
+(( $+functions[_tinty__info_commands] )) ||
+_tinty__info_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty info commands' commands "$@"
+}
+(( $+functions[_tinty__help__init_commands] )) ||
+_tinty__help__init_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty help init commands' commands "$@"
+}
+(( $+functions[_tinty__init_commands] )) ||
+_tinty__init_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty init commands' commands "$@"
+}
+(( $+functions[_tinty__help__install_commands] )) ||
+_tinty__help__install_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty help install commands' commands "$@"
+}
+(( $+functions[_tinty__install_commands] )) ||
+_tinty__install_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty install commands' commands "$@"
+}
+(( $+functions[_tinty__help__list_commands] )) ||
+_tinty__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty help list commands' commands "$@"
+}
+(( $+functions[_tinty__list_commands] )) ||
+_tinty__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty list commands' commands "$@"
+}
+(( $+functions[_tinty__help__update_commands] )) ||
+_tinty__help__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty help update commands' commands "$@"
+}
+(( $+functions[_tinty__update_commands] )) ||
+_tinty__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'tinty update commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_tinty" ]; then
+    _tinty "$@"
+else
+    compdef _tinty tinty
+fi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,10 @@
 use clap::{builder::styling, Arg, ArgAction, ArgMatches, Command};
+use clap_complete::Shell;
 
 use crate::constants::REPO_NAME;
 
 /// Builds the command-line interface for the application.
-fn build_cli() -> Command {
+pub fn build_cli() -> Command {
     Command::new(REPO_NAME)
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
@@ -25,6 +26,13 @@ fn build_cli() -> Command {
                 .long("data-dir")
                 .global(true)
                 .action(ArgAction::Set)
+        )
+        .arg(
+            Arg::new("generate-completion")
+                .long("generate-completion")
+                .value_name("SHELL")
+                .value_parser(clap::value_parser!(Shell))
+                .help("Generate completion scripts")
         )
         .subcommand(
             Command::new("current").about("Prints the last scheme name applied")

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,10 @@ mod constants;
 mod operations;
 mod utils;
 
-use crate::cli::get_matches;
+use crate::cli::{build_cli, get_matches};
 use anyhow::{anyhow, Context, Result};
+use clap::Command;
+use clap_complete::{generate, Generator, Shell};
 use config::CONFIG_FILE_NAME;
 use constants::{REPO_DIR, REPO_NAME};
 use std::path::PathBuf;
@@ -15,6 +17,14 @@ use utils::{ensure_directory_exists, replace_tilde_slash_with_home};
 fn main() -> Result<()> {
     // Parse the command line arguments
     let matches = get_matches();
+
+    // Generate completion scripts
+    if let Some(generator) = matches.get_one::<Shell>("generate-completion") {
+        let mut cmd = build_cli();
+        eprintln!("Generating completion file for {generator}...");
+        print_completions(*generator, &mut cmd);
+        return Ok(());
+    };
 
     // Other configuration paths
     let config_path_result: Result<PathBuf> =
@@ -86,4 +96,8 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
 }


### PR DESCRIPTION
This PR uses clap_complete to generate the completion script. To generate the completion script, use `tinty --generate SHELL > script_path`.

The reason why I added generated complete scripts to the Git index is that I want the schemes can be selected in completion directly. Currently, clap_complete cannot generate the complete results dynamically based on the outcome of another command, just like `tinty apply $(tinty list | fzf)` trick. Therefore, I have to manually change some places of the generated scripts.

However, I only make changes on bash only. The zsh, fish, and ps1 are untouched in this commit.

Here is the sample after `source tinty.bash` and hit Tab for completion:
![圖片](https://github.com/tinted-theming/tinty/assets/22725367/178a5503-d7f9-4167-a3ca-f2a38196c2d1)
Using [FZF Tab Completion](https://github.com/lincheney/fzf-tab-completion)
![圖片](https://github.com/tinted-theming/tinty/assets/22725367/4c3dcf0f-236a-4117-9f82-e3acc91bddaa)
