### PR TITLE
Updating README typos & More clear example

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ hook = "cp -f %f ~/.config/waybar/colors.css"
 path = "https://github.com/rkubosz/base16-sway"
 name = "base16-sway"
 themes-dir = "themes"
-hook = "cp -f %f ~/.config/sway/config && swaymsg reload"
+hook = "cp -f %f ~/.config/sway/config.d/theme && swaymsg reload"
 ```
 
 - `path`: A `path` to the repository is provided in the Tinty

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ If you're looking for a base16 or base24 builder, have a look at
 
 #### CLI mapping
 
-- `flavours apply mocha` -> `tinty set base16-mocha`
+- `flavours apply mocha` -> `tinty apply base16-mocha`
 - `flavours info mocha` -> `tinty info base16-mocha`
 - `flavours current` -> `tinty current`
 - `flavours update` -> `tinty install`
@@ -333,7 +333,7 @@ hook = "cp -f %f ~/.config/alacritty/colors.toml"
 path = "https://github.com/tinted-theming/base16-waybar"
 name = "base16-waybar"
 themes-dir = "colors"
-hook = "cp -r %f ~/.config/waybar/colors.css"
+hook = "cp -f %f ~/.config/waybar/colors.css"
 
 [[items]]
 path = "https://github.com/rkubosz/base16-sway"


### PR DESCRIPTION
Just some typos I noticed while converting from Flavours. I also updated the swaywm example to be fully functional, similar to how alacritty example works, instead of nuking the entire config:

```toml
#~/.config/alacritty/alacritty.toml
import = ["~/.config/alacritty/colors.toml"]
#...
```
and
```ini
#~/.config/sway/config
include ~/.config/sway/config.d/*
#...
```
