### PR TITLE
Feature: File-extension

### DIFF
--- a/fixtures/schemes.txt
+++ b/fixtures/schemes.txt
@@ -155,6 +155,7 @@ base16-mellow-purple
 base16-mexico-light
 base16-mocha
 base16-monokai
+base16-moonlight
 base16-mountain
 base16-nebula
 base16-nord-light
@@ -177,6 +178,10 @@ base16-pico
 base16-pinky
 base16-pop
 base16-porple
+base16-precious-dark-eleven
+base16-precious-dark-fifteen
+base16-precious-light-warm
+base16-precious-light-white
 base16-primer-dark-dimmed
 base16-primer-dark
 base16-primer-light

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 pub const DEFAULT_CONFIG_SHELL: &str = "sh -c '{}'";
 pub const CONFIG_FILE_NAME: &str = "config.toml";
-pub const BASE16_SHELL_REPO_URL: &str = "https://github.com/tinted-theming/base16-shell";
+pub const BASE16_SHELL_REPO_URL: &str = "https://github.com/tinted-theming/base16-shells";
 pub const BASE16_SHELL_REPO_NAME: &str = "base16-shells";
 pub const BASE16_SHELL_THEMES_DIR: &str = "scripts";
 pub const BASE16_SHELL_HOOK: &str = ". %f";

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,7 @@ pub struct ConfigItem {
     #[serde(rename = "supported-systems")]
     pub supported_systems: Option<Vec<SupportedSchemeSystems>>,
     #[serde(rename = "theme-file-extension")]
-    pub theme_file_extension: Option<String>
+    pub theme_file_extension: Option<String>,
 }
 
 impl fmt::Display for ConfigItem {
@@ -173,7 +173,7 @@ impl Config {
             themes_dir: BASE16_SHELL_THEMES_DIR.to_string(),
             hook: Some(BASE16_SHELL_HOOK.to_string()),
             supported_systems: Some(vec![SupportedSchemeSystems::Base16]), // DEFAULT_SCHEME_SYSTEM
-	    theme_file_extension: None
+            theme_file_extension: None,
         };
 
         // Add default `item` if no items exist

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,8 +10,8 @@ use url::Url;
 
 pub const DEFAULT_CONFIG_SHELL: &str = "sh -c '{}'";
 pub const CONFIG_FILE_NAME: &str = "config.toml";
-pub const BASE16_SHELL_REPO_URL: &str = "https://github.com/tinted-theming/base16-shells";
-pub const BASE16_SHELL_REPO_NAME: &str = "base16-shells";
+pub const BASE16_SHELL_REPO_URL: &str = "https://github.com/tinted-theming/base16-shell";
+pub const BASE16_SHELL_REPO_NAME: &str = "base16-shell";
 pub const BASE16_SHELL_THEMES_DIR: &str = "scripts";
 pub const BASE16_SHELL_HOOK: &str = ". %f";
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use url::Url;
 pub const DEFAULT_CONFIG_SHELL: &str = "sh -c '{}'";
 pub const CONFIG_FILE_NAME: &str = "config.toml";
 pub const BASE16_SHELL_REPO_URL: &str = "https://github.com/tinted-theming/base16-shell";
-pub const BASE16_SHELL_REPO_NAME: &str = "base16-shell";
+pub const BASE16_SHELL_REPO_NAME: &str = "base16-shells";
 pub const BASE16_SHELL_THEMES_DIR: &str = "scripts";
 pub const BASE16_SHELL_HOOK: &str = ". %f";
 
@@ -93,6 +93,8 @@ pub struct ConfigItem {
     pub themes_dir: String,
     #[serde(rename = "supported-systems")]
     pub supported_systems: Option<Vec<SupportedSchemeSystems>>,
+    #[serde(rename = "theme-file-extension")]
+    pub theme_file_extension: Option<String>
 }
 
 impl fmt::Display for ConfigItem {
@@ -171,6 +173,7 @@ impl Config {
             themes_dir: BASE16_SHELL_THEMES_DIR.to_string(),
             hook: Some(BASE16_SHELL_HOOK.to_string()),
             supported_systems: Some(vec![SupportedSchemeSystems::Base16]), // DEFAULT_SCHEME_SYSTEM
+	    theme_file_extension: None
         };
 
         // Add default `item` if no items exist

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -120,7 +120,8 @@ pub fn apply(config_path: &Path, data_path: &Path, full_scheme_name: &str) -> Re
                 // Run hook for item if provided
                 if let Some(hook_text) = &item.hook {
                     let hook_script =
-                        hook_text.replace("%f", format!("\"{}\"", data_theme_path.display()).as_str());
+                        hook_text.replace("%f", format!("\"{}\"", data_theme_path.display()).as_str())
+                        .replace("%n", full_scheme_name);
                     let command_vec =
                         get_shell_command_from_string(config_path, hook_script.as_str())?;
                     Command::new(&command_vec[0])

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -102,7 +102,7 @@ pub fn apply(config_path: &Path, data_path: &Path, full_scheme_name: &str) -> Re
         match theme_option {
             Some(theme_file) => {
                 let theme_file_path = &theme_file.path();
-			          let extension = theme_file_path
+                let extension = theme_file_path
                     .extension()
                     .unwrap_or_default()
                     .to_str()

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -90,7 +90,7 @@ pub fn apply(config_path: &Path, data_path: &Path, full_scheme_name: &str) -> Re
                 Some(extension) => {
                     let filename = path.file_name().and_then(|name| name.to_str());
                     format!("{}{}", full_scheme_name, extension) == filename.unwrap_or_default()
-                },
+                }
                 None => {
                     let filename = path.file_stem().and_then(|name| name.to_str());
                     full_scheme_name == filename.unwrap_or_default()

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -1,4 +1,3 @@
-
 use crate::config::{Config, SupportedSchemeSystems};
 use crate::constants::{
     CURRENT_SCHEME_FILE_NAME, DEFAULT_SCHEME_SYSTEM, REPO_DIR, REPO_NAME, REPO_URL,

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -71,6 +71,7 @@ pub fn apply(config_path: &Path, data_path: &Path, full_scheme_name: &str) -> Re
     for item in system_items {
         let repo_path = data_path.join(REPO_DIR).join(&item.name);
         let themes_path = repo_path.join(&item.themes_dir);
+
         if !themes_path.exists() {
             return Err(anyhow!(format!(
                 "Provided theme path for {} does not exist: {}\nTry running `{} install` or `{} update` or check your config.toml file and try again.",

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -121,7 +121,8 @@ pub fn apply(config_path: &Path, data_path: &Path, full_scheme_name: &str) -> Re
                 // Run hook for item if provided
                 if let Some(hook_text) = &item.hook {
                     let hook_script =
-                        hook_text.replace("%f", format!("\"{}\"", data_theme_path.display()).as_str())
+                        hook_text
+                        .replace("%f", format!("\"{}\"", data_theme_path.display()).as_str())
                         .replace("%n", full_scheme_name);
                     let command_vec =
                         get_shell_command_from_string(config_path, hook_script.as_str())?;

--- a/tests/cli_apply_subcommand_tests.rs
+++ b/tests/cli_apply_subcommand_tests.rs
@@ -240,3 +240,50 @@ hook = "echo \"path: %f\""
     cleanup()?;
     Ok(())
 }
+
+#[test]
+fn test_cli_apply_subcommand_with_config_theme_file_extension() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let scheme_name = "base16-uwunicorn";
+    let (config_path, data_path, command_vec, cleanup) = setup(
+        "test_cli_apply_subcommand_with_custom_schemes",
+        format!("apply {}", &scheme_name).as_str(),
+    )?;
+    let config_content = r#"
+[[items]]
+path = "https://github.com/tinted-theming/tinted-alacritty"
+name = "tinted-alacritty"
+themes-dir = "colors"
+hook = "echo \"expected alacritty output: %n\""
+
+[[items]]
+name = "base16-emacs"
+path = "https://github.com/tinted-theming/base16-emacs"
+theme-file-extension="-theme.el"
+themes-dir="build"
+hook = "echo \"expected emacs output: %n\""
+"#;
+    let expected_output =
+        "expected alacritty output: base16-uwunicorn\nexpected emacs output: base16-uwunicorn\n";
+    write_to_file(&config_path, config_content)?;
+
+    // ---
+    // Act
+    // ---
+    utils::run_install_command(&config_path, &data_path)?;
+    let (stdout, stderr) = utils::run_command(command_vec).unwrap();
+
+    // ------
+    // Assert
+    // ------
+    assert_eq!(stdout, expected_output,);
+    assert!(
+        stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+
+    cleanup()?;
+    Ok(())
+}


### PR DESCRIPTION
There still needs to be tests written and the documentation to be updated, but I wanted to get this out there to get some opinion on it first before committing to those.

First, the requirements for emacs that we are trying to meet:

- Theme file must end in `-theme.el`
- Theme file must be within the users `custom-theme-directory` (this one is easy)
- Theme file must be the same `theme name` as the theme provided within 
- Theme must be loaded by `theme name` via emacsclient

hurdle one was just properly identifying the emacs scheme files. The addition of an Optional parameter, `theme-file-extension` works around that: if this parameter is enabled it will search for the `scheme-name` with the `theme-file-extension` together. 

For example, `base16-nord` normally will look for any file that matches `base16-nord.*`. With `theme-file-extension="-theme.el"`, `base16-nord` will now match for any file that is `base16-nord-theme.el`. This solves our first hurdle.

The second hurdle is easily handled by hooks, but the third and fourth require an additional macro within the hook: `%n`, which provides the full scheme name. 

```toml
[[items]]
name = "base16-emacs"
path = "https://github.com/tinted-theming/base16-emacs"
theme-file-extension="-theme.el"
themes-dir="build"
hook = "cp -f %f ~/.emacs.d/themes/%n-theme.el && emacsclient -e \"(load-theme (quote %n) t)\""
```
This solves all the issues involved with tinty and supplying an appropriate theme, via `tinty apply`, to the emacs daemon. There are some other issues, but those are related to my implementation of the hook (will most likely need to be moved into a script for more elegant handling of old `-theme.el` files, persistent application of the theme, etc.)

Let me know what you think of the solution and please provide feedback. The goal is to get Tinty working with emacs the Tinty way :)

(Related to task #30) 