### PR TITLE
Do not source orphaned sh files

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -94,15 +94,17 @@ The following script does that. Add it to your shell startup file (`*rc`):
 # the way shell sub-processes work. This is a work around by running
 # Tinty through a function and then executing the shell scripts.
 tinty_source_shell_theme() {
+	newer_file=$(mktemp)
   tinty $@
   subcommand="$1"
 
   if [ "$subcommand" = "apply" ] || [ "$subcommand" = "init" ]; then
     tinty_data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tinted-theming/tinty"
 
-    for tinty_script_file in $(find "$tinty_data_dir" -maxdepth 1 -type f -name "*.sh"); do
-      . $tinty_script_file
-    done
+		while read -r script; do
+			# shellcheck disable=SC1090
+			. "$script"
+		done < <(find "$tinty_data_dir" -maxdepth 1 -type f -name "*.sh" -newer "$newer_file")
 
     unset tinty_data_dir
   fi

--- a/USAGE.md
+++ b/USAGE.md
@@ -102,8 +102,8 @@ tinty_source_shell_theme() {
     tinty_data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tinted-theming/tinty"
 
     while read -r script; do
-	    # shellcheck disable=SC1090
-	    . "$script"
+      # shellcheck disable=SC1090
+      . "$script"
     done < <(find "$tinty_data_dir" -maxdepth 1 -type f -name "*.sh" -newer "$newer_file")
 
     unset tinty_data_dir

--- a/USAGE.md
+++ b/USAGE.md
@@ -94,17 +94,17 @@ The following script does that. Add it to your shell startup file (`*rc`):
 # the way shell sub-processes work. This is a work around by running
 # Tinty through a function and then executing the shell scripts.
 tinty_source_shell_theme() {
-	newer_file=$(mktemp)
+  newer_file=$(mktemp)
   tinty $@
   subcommand="$1"
 
   if [ "$subcommand" = "apply" ] || [ "$subcommand" = "init" ]; then
     tinty_data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tinted-theming/tinty"
 
-		while read -r script; do
-			# shellcheck disable=SC1090
-			. "$script"
-		done < <(find "$tinty_data_dir" -maxdepth 1 -type f -name "*.sh" -newer "$newer_file")
+    while read -r script; do
+	    # shellcheck disable=SC1090
+	    . "$script"
+    done < <(find "$tinty_data_dir" -maxdepth 1 -type f -name "*.sh" -newer "$newer_file")
 
     unset tinty_data_dir
   fi

--- a/USAGE.md
+++ b/USAGE.md
@@ -25,13 +25,13 @@ subcommand, source the generated file in your shell startup file (`*rc`)
 and completions will exist for `tinty`. Have a look at the [README CLI
 section] for more information about the command usage.
 
-```shell
+```sh
 tinty generate-completion zsh > path/to/tinty-zsh-completion.sh
 ```
 
 In your startup file (`*rc`) add the following:
 
-```shell
+```sh
 source path/to/tinty-zsh-completion.sh
 ```
 
@@ -89,7 +89,7 @@ There is a workaround for this specific issue.
 
 The following script does that. Add it to your shell startup file (`*rc`):
 
-```shell
+```sh
 # Tinty isn't able to apply environment variables to your shell due to
 # the way shell sub-processes work. This is a work around by running
 # Tinty through a function and then executing the shell scripts.
@@ -137,7 +137,7 @@ Tinty will not apply it.
 If everything works as expected, `tinty apply
 base16-your-scheme-name.yaml` should apply your scheme.
 
-```shell
+```sh
 mkdir "$(tinty config --data-dir-path)/custom-schemes/base16"
 cp path/to/your/base16-your-scheme.yaml "$(tinty config --data-dir-path)/custom-schemes/base16/your-scheme.yaml"
 tinty list --custom-schemes # Should show your scheme
@@ -445,7 +445,7 @@ ANSI colors to be used. The available `bat` theme names for this are
 Set the alias in your `.*rc` file to make sure this is run by default
 whenever `bat` is executed.
 
-```shell
+```sh
 alias bat="bat --theme='base16-256'"
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -25,13 +25,13 @@ subcommand, source the generated file in your shell startup file (`*rc`)
 and completions will exist for `tinty`. Have a look at the [README CLI
 section] for more information about the command usage.
 
-```sh
+```shell
 tinty generate-completion zsh > path/to/tinty-zsh-completion.sh
 ```
 
 In your startup file (`*rc`) add the following:
 
-```sh
+```shell
 source path/to/tinty-zsh-completion.sh
 ```
 
@@ -89,7 +89,7 @@ There is a workaround for this specific issue.
 
 The following script does that. Add it to your shell startup file (`*rc`):
 
-```sh
+```shell
 # Tinty isn't able to apply environment variables to your shell due to
 # the way shell sub-processes work. This is a work around by running
 # Tinty through a function and then executing the shell scripts.
@@ -137,7 +137,7 @@ Tinty will not apply it.
 If everything works as expected, `tinty apply
 base16-your-scheme-name.yaml` should apply your scheme.
 
-```sh
+```shell
 mkdir "$(tinty config --data-dir-path)/custom-schemes/base16"
 cp path/to/your/base16-your-scheme.yaml "$(tinty config --data-dir-path)/custom-schemes/base16/your-scheme.yaml"
 tinty list --custom-schemes # Should show your scheme
@@ -445,7 +445,7 @@ ANSI colors to be used. The available `bat` theme names for this are
 Set the alias in your `.*rc` file to make sure this is run by default
 whenever `bat` is executed.
 
-```sh
+```shell
 alias bat="bat --theme='base16-256'"
 ```
 


### PR DESCRIPTION
I have the [tinty_source_shell_theme](https://github.com/tinted-theming/tinty/blob/main/USAGE.md#sourcing-scripts-that-set-environment-variables) function defined in my environment which runs each time I start a shell.

After noticing some oddness with my shell colors, I decided to poke around in the directory used to store the .sh files which are sourced by the function above. That's when I noticed an orphan:

```
> ls -go .local/share/tinted-theming/tinty/*.sh
-rw-rw-r-- 1 5102 Sep 15 18:00 .local/share/tinted-theming/tinty/base16-shell-scripts-file.sh
-rw-rw-r-- 1  428 Sep 24 23:14 .local/share/tinted-theming/tinty/tinted-fzf-sh-file.sh
-rw-rw-r-- 1 5109 Sep 24 23:14 .local/share/tinted-theming/tinty/tinted-shell-scripts-file.sh
```

I'm thinking I mucked something up along the way as I've been tweaking config. Regardless of how it happened, that `base16-shell-scripts-file.sh` script is an obvious orphan which should no longer be sourced. Here's what I'm doing to overcome the issue. 
