### PR TITLE
Fix bug where Tinty won't update local templates with custom schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fix bug where Tinty won't update after custom schemes have been built
+  in local templates
+
 ## [0.19.0] - 2024-09-23
 
 ### Added


### PR DESCRIPTION
When `tinty generate-scheme` has been used or custom schemes are added to `~/.local/share/tinted-theming/tinty/custom-schemes` and `tinty apply` is run, apply behaves differently: Instead of just applying the theme, it builds each template first (using `tinted-builder-rust`). This is necessary to be able to have custom schemes exist for templates. 

Currently `tinty update` checks to see if there are any diffs, if there are it does not update and asks the user to remove all of their changes to the repo first. This is where the problem lies since the templates contain themes that aren't in the git history so tinty won't update when custom schemes are used.

The change in this PR changes the diff check to allow untracked files since there is low risk of a conflict with a git pull in that case.