### PR TITLE
Release 0.20.1 - fix logging bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.20.1] - 2024-09-25
+
+### Fixed
+
+- Fix bug where `tinted-builder-rust` displays build information by
+  default when `tinty apply` is run
+
 ## [0.20.0] - 2024-09-25
 
 ### Added
@@ -178,6 +185,7 @@
 
 - Initial release
 
+[0.20.1]: https://github.com/tinted-theming/tinty/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/tinted-theming/tinty/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/tinted-theming/tinty/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/tinted-theming/tinty/compare/v0.17.0...v0.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "tinty"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tinty"
 description = "Change the theme of your terminal, text editor and anything else with one command!"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -84,7 +84,7 @@ pub fn apply(
                         let item_template_path: PathBuf =
                             data_path.join(format!("{}/{}", REPO_DIR, &item_name));
 
-                        build(&item_template_path, custom_schemes_path, is_quiet)?;
+                        build(&item_template_path, custom_schemes_path, true)?;
                     }
 
                     Ok(())

--- a/tests/cli_apply_subcommand_tests.rs
+++ b/tests/cli_apply_subcommand_tests.rs
@@ -178,10 +178,6 @@ fn test_cli_apply_subcommand_with_custom_schemes() -> Result<()> {
     )?;
     let custom_scheme_file_path =
         data_path.join(format!("custom-schemes/base16/{}.yaml", scheme_name));
-    let expected_output = format!(
-        r#"Successfully generated "base16" themes for "base16" at "{}/repos/tinted-shell/scripts/*.sh"#,
-        data_path.display()
-    );
     let current_scheme_path = data_path.join(CURRENT_SCHEME_FILE_NAME);
     let scheme_content =
         fs::read_to_string(Path::new("./tests/fixtures/schemes/tinty-generated.yaml"))?;
@@ -201,7 +197,7 @@ fn test_cli_apply_subcommand_with_custom_schemes() -> Result<()> {
         scheme_name_with_system,
     );
     assert!(
-        stdout.contains(&expected_output),
+        stdout.is_empty(),
         "stdout does not contain the expected output"
     );
     assert!(


### PR DESCRIPTION
Fix bug where tinted-builder-rust displays logging information when `cargo apply` is run