### PR TITLE
BREAKING: Put MacOS in line with Linux with regards to config and data directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- BREAKING: MacOS breaking change only since Tinty now uses `XDG` paths
+  for config and data directories while falling back to `XDG` defaults 
+  for these dirs if the environment variables aren't set. This is how 
+  Tinty functions on Linux already
+
 ## [0.20.1] - 2024-09-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,8 +1350,8 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
- "dirs",
  "hex_color",
+ "home",
  "serde",
  "serde_yaml",
  "shell-words",
@@ -1352,6 +1361,7 @@ dependencies = [
  "tinted-scheme-extractor",
  "toml",
  "url",
+ "xdg",
 ]
 
 [[package]]
@@ -1704,6 +1714,12 @@ checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["command-line-utilities"]
 anyhow = "1.0.89"
 clap = { version = "4.5.4", features = ["derive"] }
 clap_complete = { version = "4.5.29" }
-dirs = "5.0.1"
 hex_color = "3.0.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_yaml = "0.9.31"
@@ -26,3 +25,5 @@ tinted-builder= "0.7.0"
 tinted-scheme-extractor = "0.4.0"
 toml = "0.8.19"
 url = "2.5.2"
+xdg = "2.5.2"
+home = "0.5.9"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::constants::REPO_NAME;
 use anyhow::{anyhow, Context, Result};
+use home::home_dir;
 use serde::de::{self, Deserializer, Unexpected, Visitor};
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -10,6 +11,7 @@ use url::Url;
 
 pub const DEFAULT_CONFIG_SHELL: &str = "sh -c '{}'";
 pub const CONFIG_FILE_NAME: &str = "config.toml";
+pub const ORG_NAME: &str = "tinted-theming";
 pub const BASE16_SHELL_REPO_URL: &str = "https://github.com/tinted-theming/tinted-shell";
 pub const BASE16_SHELL_REPO_NAME: &str = "tinted-shell";
 pub const BASE16_SHELL_THEMES_DIR: &str = "scripts";
@@ -196,7 +198,7 @@ impl Config {
                 // Replace `~/` with absolute home path
                 let trimmed_path = item.path.trim();
                 if trimmed_path.starts_with("~/") {
-                    match dirs::home_dir() {
+                    match home_dir() {
                         Some(home_dir) => {
                             item.path = trimmed_path.replacen(
                                 "~/",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::config::{Config, ConfigItem, SupportedSchemeSystems, DEFAULT_CONFIG_SHELL};
 use crate::constants::{REPO_NAME, SCHEME_EXTENSION};
 use anyhow::{anyhow, Context, Result};
+use home::home_dir;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -171,14 +172,14 @@ pub fn get_all_scheme_names(
 pub fn replace_tilde_slash_with_home(path_str: &str) -> Result<PathBuf> {
     let trimmed_path_str = path_str.trim();
     if trimmed_path_str.starts_with("~/") {
-        match dirs::home_dir() {
-                Some(home_dir) => Ok(PathBuf::from(trimmed_path_str.replacen(
-                        "~/",
-                        format!("{}/", home_dir.display()).as_str(),
-                        1,
-                    ))),
-                None => Err(anyhow!("Unable to determine a home directory for \"{}\", please use an absolute path instead", trimmed_path_str))
-            }
+        match home_dir() {
+            Some(home_dir) => Ok(PathBuf::from(trimmed_path_str.replacen(
+                "~/",
+                format!("{}/", home_dir.display()).as_str(),
+                1,
+            ))),
+            None => Err(anyhow!("Unable to determine a home directory for \"{}\", please use an absolute path instead", trimmed_path_str))
+        }
     } else {
         Ok(PathBuf::from(trimmed_path_str))
     }

--- a/tests/cli_general_tests.rs
+++ b/tests/cli_general_tests.rs
@@ -2,9 +2,9 @@ mod utils;
 
 use crate::utils::{
     cleanup, read_file_to_string, setup, write_to_file, COMMAND_NAME, CURRENT_SCHEME_FILE_NAME,
-    REPO_NAME,
+    ORG_NAME, REPO_NAME,
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::{fs, path::PathBuf};
 
 #[test]
@@ -36,7 +36,7 @@ fn test_cli_config_path_tilde_as_home() -> Result<()> {
     // -------
     let name = "test_cli_config_path_tilde_as_home";
     let config_path_name = format!("config_path_{}", name);
-    let home_path = dirs::home_dir().unwrap();
+    let home_path = home::home_dir().unwrap();
     let config_path = home_path.join(&config_path_name);
     let provided_config_path = format!("~/{}", config_path_name);
     let data_path = PathBuf::from(format!("data_path_{}", name));
@@ -87,9 +87,9 @@ fn test_cli_default_data_path() -> Result<()> {
     let config_path = PathBuf::from(format!("{}.toml", "test_cli_default_data_path"));
     let scheme_name = "base16-uwunicorn";
     let init_scheme_name = "base16-mocha";
-    let data_path = dirs::data_dir()
-        .ok_or_else(|| anyhow!("Error getting data directory"))?
-        .join(format!("tinted-theming/{}", REPO_NAME));
+    let xdg_dirs =
+        xdg::BaseDirectories::with_prefix(format!("{}/{}", ORG_NAME, REPO_NAME)).unwrap();
+    let data_path = xdg_dirs.get_data_home();
     let init_command = format!(
         "{} --config=\"{}\" init",
         COMMAND_NAME,
@@ -159,7 +159,7 @@ fn test_cli_data_path_tilde_as_home() -> Result<()> {
     // Arrange
     // -------
     let data_path_name = "test_cli_data_path_tilde_as_home";
-    let home_path = dirs::home_dir().unwrap();
+    let home_path = home::home_dir().unwrap();
     let config_path = PathBuf::from(format!("{}.toml", data_path_name));
     let data_path = home_path.join(data_path_name);
     let provided_data_path = format!("~/{}", data_path_name);

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -8,6 +8,8 @@ use std::str;
 
 #[allow(dead_code)]
 pub const REPO_NAME: &str = env!("CARGO_PKG_NAME");
+#[allow(dead_code)]
+pub const ORG_NAME: &str = "tinted-theming";
 pub const COMMAND_NAME: &str = "./target/release/tinty";
 #[allow(dead_code)]
 pub const CURRENT_SCHEME_FILE_NAME: &str = "current_scheme";


### PR DESCRIPTION
Related to GitHub Issue: https://github.com/tinted-theming/tinty/issues/62

**MacOS**: This is a breaking change and changes the directories Tinty uses on MacOS for config and data directories. Tinty looks at whether `XDG` paths are set and uses them, otherwise it falls back to the `XDG` default paths for these directories.

**Linux**: This is how things functioned on linux already so there shouldn't be any noticeable changes.

**More technical details**: Replace `dirs` crate with `xdg` and `home` crates.