### PR TITLE
Trim vim system commands

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -218,7 +218,7 @@ local function get_tinty_theme()
   if vim.v.shell_error ~= 0 then
     return default_theme
   else
-    return theme_name
+    return vim.trim(theme_name)
   end
 end
 
@@ -258,7 +258,7 @@ function! GetTintyTheme()
   if v:shell_error != 0
     return g:default_theme
   else
-    return l:theme_name
+    return trim(l:theme_name)
   endif
 endfunction
 


### PR DESCRIPTION
When vim executes a system command it gets the full string response, including the trailing newline character

This newline needs to be trimmed off the end of the return value before doing a string comparison with the value of the existing colorscheme

This prevents the focus handler resetting the colorscheme every time it's called, but rather just when an actual change has occurred