### PR TITLE
Add feature to get specific scheme information from current scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Support arguments with `current` subcommand to allow consumers to get
+  specific current scheme data
+
 ## [0.21.1] - 2024-10-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The following is a table of the available subcommands for the CLI tool (Tinty), 
 | `list`     | Lists all available themes. | Optional argument `--custom-schemes` to list saved custom theme files using `tinty generate-scheme` | `tinty list` |
 | `apply`    | Applies a specific theme. | `<scheme_system>-<scheme_name>`: Name of the system and scheme to apply. | `tinty apply base16-mocha` |
 | `init`     | Initializes the tool with the last applied theme otherwise `default-scheme` from `config.toml`. | - | `tinty init` |
-| `current`  | Displays the currently applied theme. | - | `tinty current` |
+| `current`  | Displays the currently applied theme or current theme values. | `<scheme_property_name>` (Optional argument with the following supported values: `author` \| `description` \| `name` \| `slug` \| `system` \| `variant`) | `tinty current` |
 | `config`   | Displays config related information currently in use by Tinty. Without flags it returns `config.yml` content. | - | `tinty config` |
 | `info`     | Provides information about themes. | `[<scheme_system>-<scheme_name>]`: Optional argument `--custom-schemes` to provide information on any custom schemes | `tinty info base16-mocha` |
 | `build`    | Builds the provided base16 or base24 template using [tinted-builder-rust]. | `<DIR>`: Path to the base16 or base24 template directory. | `tinty build path/to/tinted-tmux` |

--- a/contrib/completion/tinty.bash
+++ b/contrib/completion/tinty.bash
@@ -217,7 +217,7 @@ _tinty() {
             return 0
             ;;
         tinty__current)
-            opts="-c -d -h --config --data-dir --help"
+            opts="-c -d -h --config --data-dir --help author description name slug system variant"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completion/tinty.elvish
+++ b/contrib/completion/tinty.elvish
@@ -27,7 +27,7 @@ set edit:completion:arg-completer[tinty] = {|@words|
             cand -V 'Print version'
             cand --version 'Print version'
             cand build 'Builds the target theme template'
-            cand current 'Prints the last scheme name applied'
+            cand current 'Prints the last scheme name applied or specific values from the current scheme'
             cand generate-completion 'Generates a shell completion script'
             cand generate-scheme 'Generates a scheme based on an image'
             cand info 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)'
@@ -159,7 +159,7 @@ set edit:completion:arg-completer[tinty] = {|@words|
         }
         &'tinty;help'= {
             cand build 'Builds the target theme template'
-            cand current 'Prints the last scheme name applied'
+            cand current 'Prints the last scheme name applied or specific values from the current scheme'
             cand generate-completion 'Generates a shell completion script'
             cand generate-scheme 'Generates a scheme based on an image'
             cand info 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)'

--- a/contrib/completion/tinty.fish
+++ b/contrib/completion/tinty.fish
@@ -29,7 +29,7 @@ complete -c tinty -n "__fish_tinty_needs_command" -s d -l data-dir -d 'Optional 
 complete -c tinty -n "__fish_tinty_needs_command" -s h -l help -d 'Print help'
 complete -c tinty -n "__fish_tinty_needs_command" -s V -l version -d 'Print version'
 complete -c tinty -n "__fish_tinty_needs_command" -f -a "build" -d 'Builds the target theme template'
-complete -c tinty -n "__fish_tinty_needs_command" -f -a "current" -d 'Prints the last scheme name applied'
+complete -c tinty -n "__fish_tinty_needs_command" -f -a "current" -d 'Prints the last scheme name applied or specific values from the current scheme'
 complete -c tinty -n "__fish_tinty_needs_command" -f -a "generate-completion" -d 'Generates a shell completion script'
 complete -c tinty -n "__fish_tinty_needs_command" -f -a "generate-scheme" -d 'Generates a scheme based on an image'
 complete -c tinty -n "__fish_tinty_needs_command" -f -a "info" -d 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)'
@@ -39,6 +39,7 @@ complete -c tinty -n "__fish_tinty_needs_command" -f -a "config" -d 'Provides co
 complete -c tinty -n "__fish_tinty_needs_command" -f -a "apply" -d 'Applies a theme based on the chosen scheme'
 complete -c tinty -n "__fish_tinty_needs_command" -f -a "install" -d 'Install the environment needed for tinty'
 complete -c tinty -n "__fish_tinty_needs_command" -f -a "update" -d 'Update to the latest themes'
+complete -c tinty -n "__fish_tinty_needs_command" -f -a "sync" -d 'Install missing templates in tinty/config.toml and update existing templates'
 complete -c tinty -n "__fish_tinty_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c tinty -n "__fish_tinty_using_subcommand build" -s c -l config -d 'Optional path to the tinty config.toml file' -r
 complete -c tinty -n "__fish_tinty_using_subcommand build" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
@@ -78,22 +79,30 @@ complete -c tinty -n "__fish_tinty_using_subcommand config" -l data-dir-path -d 
 complete -c tinty -n "__fish_tinty_using_subcommand config" -s h -l help -d 'Print help'
 complete -c tinty -n "__fish_tinty_using_subcommand apply" -s c -l config -d 'Optional path to the tinty config.toml file' -r
 complete -c tinty -n "__fish_tinty_using_subcommand apply" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_tinty_using_subcommand apply" -s q -l quiet -d 'Silence stdout'
 complete -c tinty -n "__fish_tinty_using_subcommand apply" -s h -l help -d 'Print help'
 complete -c tinty -n "__fish_tinty_using_subcommand install" -s c -l config -d 'Optional path to the tinty config.toml file' -r
 complete -c tinty -n "__fish_tinty_using_subcommand install" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_tinty_using_subcommand install" -s q -l quiet -d 'Silence stdout'
 complete -c tinty -n "__fish_tinty_using_subcommand install" -s h -l help -d 'Print help'
 complete -c tinty -n "__fish_tinty_using_subcommand update" -s c -l config -d 'Optional path to the tinty config.toml file' -r
 complete -c tinty -n "__fish_tinty_using_subcommand update" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_tinty_using_subcommand update" -s q -l quiet -d 'Silence stdout'
 complete -c tinty -n "__fish_tinty_using_subcommand update" -s h -l help -d 'Print help'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "build" -d 'Builds the target theme template'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "current" -d 'Prints the last scheme name applied'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "generate-completion" -d 'Generates a shell completion script'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "generate-scheme" -d 'Generates a scheme based on an image'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "info" -d 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "init" -d 'Initializes with the exising config. Used to Initialize exising theme for when your shell starts up'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "list" -d 'Lists available schemes'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "config" -d 'Provides config related information'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "apply" -d 'Applies a theme based on the chosen scheme'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "install" -d 'Install the environment needed for tinty'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "update" -d 'Update to the latest themes'
-complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c tinty -n "__fish_tinty_using_subcommand sync" -s c -l config -d 'Optional path to the tinty config.toml file' -r
+complete -c tinty -n "__fish_tinty_using_subcommand sync" -s d -l data-dir -d 'Optional path to the tinty data directory' -r
+complete -c tinty -n "__fish_tinty_using_subcommand sync" -s q -l quiet -d 'Silence stdout'
+complete -c tinty -n "__fish_tinty_using_subcommand sync" -s h -l help -d 'Print help'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "build" -d 'Builds the target theme template'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "current" -d 'Prints the last scheme name applied or specific values from the current scheme'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "generate-completion" -d 'Generates a shell completion script'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "generate-scheme" -d 'Generates a scheme based on an image'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "info" -d 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "init" -d 'Initializes with the exising config. Used to Initialize exising theme for when your shell starts up'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "list" -d 'Lists available schemes'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "config" -d 'Provides config related information'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "apply" -d 'Applies a theme based on the chosen scheme'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "install" -d 'Install the environment needed for tinty'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "update" -d 'Update to the latest themes'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "sync" -d 'Install missing templates in tinty/config.toml and update existing templates'
+complete -c tinty -n "__fish_tinty_using_subcommand help; and not __fish_seen_subcommand_from build current generate-completion generate-scheme info init list config apply install update sync help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/contrib/completion/tinty.powershell
+++ b/contrib/completion/tinty.powershell
@@ -30,7 +30,7 @@ Register-ArgumentCompleter -Native -CommandName 'tinty' -ScriptBlock {
             [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
             [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
             [CompletionResult]::new('build', 'build', [CompletionResultType]::ParameterValue, 'Builds the target theme template')
-            [CompletionResult]::new('current', 'current', [CompletionResultType]::ParameterValue, 'Prints the last scheme name applied')
+            [CompletionResult]::new('current', 'current', [CompletionResultType]::ParameterValue, 'Prints the last scheme name applied or specific values from the current scheme')
             [CompletionResult]::new('generate-completion', 'generate-completion', [CompletionResultType]::ParameterValue, 'Generates a shell completion script')
             [CompletionResult]::new('generate-scheme', 'generate-scheme', [CompletionResultType]::ParameterValue, 'Generates a scheme based on an image')
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)')
@@ -175,7 +175,7 @@ Register-ArgumentCompleter -Native -CommandName 'tinty' -ScriptBlock {
         }
         'tinty;help' {
             [CompletionResult]::new('build', 'build', [CompletionResultType]::ParameterValue, 'Builds the target theme template')
-            [CompletionResult]::new('current', 'current', [CompletionResultType]::ParameterValue, 'Prints the last scheme name applied')
+            [CompletionResult]::new('current', 'current', [CompletionResultType]::ParameterValue, 'Prints the last scheme name applied or specific values from the current scheme')
             [CompletionResult]::new('generate-completion', 'generate-completion', [CompletionResultType]::ParameterValue, 'Generates a shell completion script')
             [CompletionResult]::new('generate-scheme', 'generate-scheme', [CompletionResultType]::ParameterValue, 'Generates a scheme based on an image')
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg: tinty info base16-mocha)')

--- a/contrib/completion/tinty.zsh
+++ b/contrib/completion/tinty.zsh
@@ -53,6 +53,7 @@ _arguments "${_arguments_options[@]}" : \
 '--data-dir=[Optional path to the tinty data directory]:DIRECTORY: ' \
 '-h[Print help]' \
 '--help[Print help]' \
+'::property_name -- Optional field to retrieve scheme information for\: author, description, name, etc.:(author description name slug system variant)' \
 && ret=0
 ;;
 (generate-completion)
@@ -256,7 +257,7 @@ esac
 _tinty_commands() {
     local commands; commands=(
 'build:Builds the target theme template' \
-'current:Prints the last scheme name applied' \
+'current:Prints the last scheme name applied or specific values from the current scheme' \
 'generate-completion:Generates a shell completion script' \
 'generate-scheme:Generates a scheme based on an image' \
 'info:Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg\: tinty info base16-mocha)' \
@@ -305,7 +306,7 @@ _tinty__generate-scheme_commands() {
 _tinty__help_commands() {
     local commands; commands=(
 'build:Builds the target theme template' \
-'current:Prints the last scheme name applied' \
+'current:Prints the last scheme name applied or specific values from the current scheme' \
 'generate-completion:Generates a shell completion script' \
 'generate-scheme:Generates a scheme based on an image' \
 'info:Shows scheme colors for all schemes matching <scheme_system>-<scheme_name> (Eg\: tinty info base16-mocha)' \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,7 +48,21 @@ pub fn build_cli() -> Command {
 
         )
         .subcommand(
-            Command::new("current").about("Prints the last scheme name applied")
+            Command::new("current")
+                .about("Prints the last scheme name applied or specific values from the current scheme")
+                .arg(
+                    Arg::new("property_name")
+                        .help("Optional field to retrieve scheme information for: author, description, name, etc.")
+                        .value_parser([
+                            PossibleValue::new("author"),
+                            PossibleValue::new("description"),
+                            PossibleValue::new("name"),
+                            PossibleValue::new("slug"),
+                            PossibleValue::new("system"),
+                            PossibleValue::new("variant"),
+                        ])
+                        .required(false)
+                )
         )
         .subcommand(
             Command::new("generate-completion").about("Generates a shell completion script").arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,8 +75,13 @@ fn main() -> Result<()> {
                 operations::build::build(&template_path, &schemes_repo_path)?;
             }
         }
-        Some(("current", _)) => {
-            operations::current::current(&data_path)?;
+        Some(("current", sub_matches)) => {
+            let property_name = sub_matches
+                .get_one::<String>("property_name")
+                .map(|s| s.as_str())
+                .unwrap_or_default();
+
+            operations::current::current(&data_path, property_name)?;
         }
         Some(("config", sub_matches)) => {
             let data_dir_path_flag = sub_matches.get_flag("data-dir-path");

--- a/src/operations/current.rs
+++ b/src/operations/current.rs
@@ -1,19 +1,98 @@
-use crate::constants::CURRENT_SCHEME_FILE_NAME;
+use crate::constants::{
+    CURRENT_SCHEME_FILE_NAME, CUSTOM_SCHEMES_DIR_NAME, REPO_DIR, REPO_NAME, SCHEMES_REPO_NAME,
+};
 use anyhow::{anyhow, Result};
 use std::fs;
 use std::path::Path;
+use tinted_builder_rust::utils::get_scheme_files;
 
 /// Prints out the name of the last scheme applied
-pub fn current(data_path: &Path) -> Result<()> {
-    let current_scheme_name = fs::read_to_string(data_path.join(CURRENT_SCHEME_FILE_NAME)).ok();
+pub fn current(data_path: &Path, property_name: &str) -> Result<()> {
+    let current_scheme_slug =
+        fs::read_to_string(data_path.join(CURRENT_SCHEME_FILE_NAME)).unwrap_or_default();
+    let schemes_path = data_path.join(format!("{}/{}", REPO_DIR, SCHEMES_REPO_NAME));
 
-    match current_scheme_name {
-        Some(scheme_name) => {
-            println!("{}", scheme_name);
-            Ok(())
-        }
-        None => Err(anyhow!(
+    if current_scheme_slug.is_empty() {
+        return Err(anyhow!(
             "Failed to read last scheme from file. Try applying a scheme and try again."
-        )),
+        ));
     }
+
+    if property_name.is_empty() {
+        println!("{}", current_scheme_slug);
+
+        return Ok(());
+    }
+
+    if !schemes_path.is_dir() {
+        return Err(anyhow!(
+            "No schemes exist. Run `{} sync` and try again.",
+            REPO_NAME
+        ));
+    }
+
+    let custom_schemes_path = data_path.join(CUSTOM_SCHEMES_DIR_NAME);
+    let scheme_files = {
+        let mut scheme_files = get_scheme_files(&schemes_path, true)?;
+
+        if custom_schemes_path.is_dir() {
+            let custom_scheme_files = get_scheme_files(&custom_schemes_path, true)?;
+            scheme_files.extend(custom_scheme_files);
+        }
+
+        scheme_files
+    };
+
+    let current_scheme_container = scheme_files.iter().find_map(|scheme_file| {
+        let path = scheme_file.get_path().unwrap_or_default();
+        let file_stem = path
+            .file_stem()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap_or_default();
+
+        if current_scheme_slug.contains(file_stem) {
+            if let Ok(scheme) = scheme_file.get_scheme() {
+                let scheme_slug = scheme.get_scheme_slug();
+                let system = scheme.get_scheme_system();
+                let tinty_slug = format!("{}-{}", system, scheme_slug);
+
+                if tinty_slug == current_scheme_slug {
+                    return Some(scheme);
+                }
+            }
+        }
+
+        None
+    });
+
+    if let Some(current_scheme_container) = current_scheme_container {
+        match property_name {
+            "author" => {
+                println!("{}", current_scheme_container.get_scheme_author());
+            }
+            "description" => {
+                println!("{}", current_scheme_container.get_scheme_description());
+            }
+            "name" => {
+                println!("{}", current_scheme_container.get_scheme_name());
+            }
+            "slug" => {
+                println!("{}", current_scheme_container.get_scheme_slug());
+            }
+            "system" => {
+                println!("{}", current_scheme_container.get_scheme_system());
+            }
+            "variant" => {
+                println!("{}", current_scheme_container.get_scheme_variant());
+            }
+            _ => {
+                eprintln!("Unable to find property: {}", property_name);
+            }
+        }
+    } else {
+        eprintln!("Unable to find property: {}", property_name);
+    }
+
+    Ok(())
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -13,6 +13,10 @@ pub const ORG_NAME: &str = "tinted-theming";
 pub const COMMAND_NAME: &str = "./target/release/tinty";
 #[allow(dead_code)]
 pub const CURRENT_SCHEME_FILE_NAME: &str = "current_scheme";
+#[allow(dead_code)]
+pub const REPO_DIR: &str = "repos";
+#[allow(dead_code)]
+pub const SCHEMES_REPO_NAME: &str = "schemes";
 
 pub fn run_command(command_vec: Vec<String>) -> Result<(String, String), Box<dyn Error>> {
     let output = Command::new(&command_vec[0])
@@ -112,4 +116,22 @@ pub fn setup(
         command_vec,
         Box::new(move || cleanup(&config_path_clone, &data_path_clone)),
     ))
+}
+
+#[allow(dead_code)]
+pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
+    fs::create_dir_all(&dst)?;
+
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let dest_path = dst.as_ref().join(entry.file_name());
+
+        if file_type.is_dir() {
+            copy_dir_all(entry.path(), &dest_path)?;
+        } else {
+            fs::copy(entry.path(), &dest_path)?;
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
Adds optional argument for `tinty current <arg>` subcommand. Accepted arg value options are `author`, `description`,  `name`, `slug`, `system`, `variant`.  This is backward compatible since `tinty current` will function the same as it did before.