### PR TITLE
Add arch linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ brew tap tinted-theming/tinted
 brew install tinty
 ```
 
+### Arch linux
+
+```sh
+paru -S tinty-git
+```
+
 ### Binaries
 
 Download the relevant binary from the [repository releases] page.


### PR DESCRIPTION
I packaged `tinty` for the AUR, it is available here: https://aur.archlinux.org/packages/tinty-git

I added the install instructions.

closes #76 