### PR TITLE
tests/utils: use CARGO_BIN_EXE* to find tinty executable

### DIFF
--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -10,7 +10,7 @@ use std::str;
 pub const REPO_NAME: &str = env!("CARGO_PKG_NAME");
 #[allow(dead_code)]
 pub const ORG_NAME: &str = "tinted-theming";
-pub const COMMAND_NAME: &str = "./target/release/tinty";
+pub const COMMAND_NAME: &str = env!("CARGO_BIN_EXE_tinty");
 #[allow(dead_code)]
 pub const CURRENT_SCHEME_FILE_NAME: &str = "current_scheme";
 #[allow(dead_code)]


### PR DESCRIPTION
Assuming that the executable always lives in `./target/release/tinty` is not sound depending on the Cargo setup. Instead, one should rely on existing environment variables to be more robust (see https://doc.rust-lang.org/cargo/reference/environment-variables.html)