### PR TITLE
fix: generate file have trailing dot of theme file doesn't have a file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fix bug where period preceeding extension is still added to generated files even when an extension doesn't exist
+
 ## [0.24.0] - 2024-12-20
 
 ### Changed

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -149,13 +149,12 @@ pub fn apply(
         match theme_option {
             Some(theme_file) => {
                 let theme_file_path = &theme_file.path();
-                let extension = theme_file_path
-                    .extension()
-                    .unwrap_or_default()
-                    .to_str()
-                    .unwrap_or_default();
+                let extension = match theme_file_path.extension() {
+                    Some(ext) => format!(".{}", ext.to_str().unwrap_or_default()),
+                    None => String::new(),
+                };
                 let filename = format!(
-                    "{}.{}",
+                    "{}{}",
                     create_theme_filename_without_extension(item)?,
                     extension,
                 );


### PR DESCRIPTION
☝️ As the title says, if the theme file doesn't have a file extension, the generated file will have a trailing dot e.g.:

```sh
~/.local/share/tinted-theming/tinty/repos/tinted-terminal/themes/ghostty/base16-3024

# ... produces:

~/.local/share/tinted-theming/tinty/tinted-terminal-themes-ghostty-file.

```

This is probably not a common case, but Ghostty uses the theme filename as the theme name itself. This patch makes it so that these kinds of files are copied over without an extension.

(I'm new to Rust 🙃 so apologies in advance!)