### PR TITLE
Fix bug where `--branches` flag doesn't exist for some versions of git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Fixed a bug where scheme files ending in `.yml` weren't recognized.
+- Fixed a bug where `install` subcommand gives an error for older versions of
+  git
 
 ## [0.26.0] - 2025-01-18
 


### PR DESCRIPTION
Related to https://github.com/tinted-theming/tinty/issues/100

- Remove `--branches` flag. I know the flag limits it to branches, but I don't think it shouldn't ever match anything else.
- Fixes in the file suggested by `cargo clippy`