### PR TITLE
chore: update known scheme count in test assertions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -45,3 +45,8 @@ deny = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0436", # paste crate is unmaintained
+]

--- a/tests/cli_list_subcommand_tests.rs
+++ b/tests/cli_list_subcommand_tests.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use tinted_builder::{SchemeSystem, SchemeVariant};
 use utils::setup;
 
-const SCHEME_COUNT: usize = 287;
+const SCHEME_COUNT: usize = 438;
 
 #[test]
 fn test_cli_list_subcommand_without_setup() -> Result<()> {


### PR DESCRIPTION
There are a lot more Base24 schemes now