### PR TITLE
feat: implement `tinty cycle`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Cargo.lock
 # Test generated files
 /data_path_*
 /config_path_*
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
+### Added
 
-## Fixed
-
-- Fix bugs caused by vestigial theme files in the data directory. They are now cleaned up during `tinty apply`.
+- New `tinty cycle` command to cycle through a small list of schemes you curate in your config's `preferred-schemes`
+property.
 
 ## Changed
 
@@ -13,6 +13,10 @@
 compatibility, symlinks are
 created in the root of the data directory pointing to their new locations. These symlinks will go
 away in a future Tinty release.
+
+## Fixed
+
+- Fix bugs caused by vestigial theme files in the data directory. They are now cleaned up during `tinty apply`.
 
 ## [0.27.0] - 2025-03-26
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The following is a table of the available subcommands for the CLI tool (Tinty), 
 | `sync`     | Installs and updates schemes and templates defined in `tinty/config.toml` | - | `tinty sync` |
 | `list`     | Lists all available themes. | Optional argument `--custom-schemes` to list saved custom theme files using `tinty generate-scheme`.<br>Optional argument `--json` to output more info about each scheme in JSON form | `tinty list` |
 | `apply`    | Applies a specific theme. | `<scheme_system>-<scheme_name>`: Name of the system and scheme to apply. | `tinty apply base16-mocha` |
+| `cycle`    | Applies the next theme among your preferred ones. See [Configuration](#configuration).  |  | `tinty cycle` |
 | `init`     | Initializes the tool with the last applied theme otherwise `default-scheme` from `config.toml`. | - | `tinty init` |
 | `current`  | Displays the currently applied theme or current theme values. | `<scheme_property_name>` (Optional argument with the following supported values: `author` \| `description` \| `name` \| `slug` \| `system` \| `variant`) | `tinty current` |
 | `config`   | Displays config related information currently in use by Tinty. Without flags it returns `config.yml` content. | - | `tinty config` |
@@ -211,6 +212,7 @@ to your preferences and environment.
 |-------------------|--------------------|----------|----------------------------------------------------------------------------------------|---------|---------|
 | `shell`           | `string`           | Optional | Specifies the shell command used to execute hooks. | `"sh -c '{}'"` | `shell = "bash -c '{}'"` |
 | `default-scheme`  | `string`           | Optional | Defines the default theme scheme to be applied if no specific scheme is set. | None | `default-scheme = "base16-mocha"` |
+| `preferred-schemes`  | `array<string>`           | Optional | A list of your favorite theme schemes you'd like to cycle through  | `[]` | `preferred-schemes = ["base16-gruvbox-dark", "base16-gruvbox-light"]` |
 | `hooks`           | `array<string>`    | Optional | A list of strings which are executed after every `tinty apply` | None | `hooks = ["echo \"The current scheme is: $(tinty current)\""]` |
 | `[[items]]`       | `array<items>`     | Required | An array of `items` configurations. Each item represents a themeable component. Detailed structure provided in the next section. | - | - |
 
@@ -287,6 +289,7 @@ multiple items along with global settings:
 # Global settings
 shell = "zsh -c '{}'"
 default-scheme = "base16-mocha"
+preferred-schemes = ["base16-gruvbox-dark", "base16-gruvbox-light", "base16-github-dark"]
 
 # Item configurations
 [[items]]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,6 +233,16 @@ pub fn build_cli() -> Command {
                         .action(ArgAction::SetTrue),
                 ),
         )
+        .subcommand(
+            Command::new("cycle").about("Cycle through your preferred themes")
+                .arg(
+                    Arg::new("quiet")
+                        .long("quiet")
+                        .short('q')
+                        .help("Silence stdout")
+                        .action(ArgAction::SetTrue),
+                )
+        )
 }
 
 // Parse the command line arguments with styling

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,8 @@ pub struct Config {
     pub shell: Option<String>,
     #[serde(rename = "default-scheme")]
     pub default_scheme: Option<String>,
+    #[serde(rename = "preferred-schemes")]
+    pub preferred_schemes: Option<Vec<String>>,
     pub items: Option<Vec<ConfigItem>>,
     pub hooks: Option<Vec<String>>,
 }
@@ -177,12 +179,23 @@ impl fmt::Display for Config {
             "shell = \"{}\"",
             self.shell.as_ref().unwrap_or(&"None".to_string())
         )?;
-        if self.default_scheme.is_some() {
+
+        if let Some(default_scheme) = &self.default_scheme {
             writeln!(
                 f,
                 "default-scheme = \"{}\"",
-                self.default_scheme.as_ref().unwrap_or(&"".to_string())
+                default_scheme
             )?;
+        }
+
+        if let Some(items) = &self.preferred_schemes {
+            let preferred_schemes_text = items
+                .clone()
+                .into_iter()
+                .map(|t| format!("\"{}\"", t))
+                .collect::<Vec<String>>()
+                .join(", ");
+            writeln!(f, "preferred-schemes = [{}]", preferred_schemes_text)?;
         }
 
         if let Some(items) = &self.items {

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,11 +181,7 @@ impl fmt::Display for Config {
         )?;
 
         if let Some(default_scheme) = &self.default_scheme {
-            writeln!(
-                f,
-                "default-scheme = \"{}\"",
-                default_scheme
-            )?;
+            writeln!(f, "default-scheme = \"{}\"", default_scheme)?;
         }
 
         if let Some(items) = &self.preferred_schemes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod operations {
     pub mod build;
     pub mod config;
     pub mod current;
+    pub mod cycle;
     pub mod generate_scheme;
     pub mod info;
     pub mod init;
@@ -142,6 +143,15 @@ fn main() -> Result<()> {
                 operations::apply::apply(&config_path, &data_path, scheme_name, is_quiet, None)
                     .with_context(|| format!("Failed to apply theme \"{:?}\"", scheme_name))?;
             }
+        }
+        Some(("cycle", sub_matches)) => {
+            let is_quiet = sub_matches
+                .get_one::<bool>("quiet")
+                .map(|b| b.to_owned())
+                .unwrap_or(false);
+
+            operations::cycle::cycle(&config_path, &data_path, is_quiet, None)
+                .with_context(|| format!("Failed to cycle to your next preferred theme"))?;
         }
         Some(("install", sub_matches)) => {
             let is_quiet = sub_matches

--- a/src/operations/current.rs
+++ b/src/operations/current.rs
@@ -6,10 +6,13 @@ use std::fs;
 use std::path::Path;
 use tinted_builder_rust::utils::get_scheme_files;
 
+pub fn get_current_scheme_slug(data_path: &Path) -> String {
+    fs::read_to_string(data_path.join(CURRENT_SCHEME_FILE_NAME)).unwrap_or_default()
+}
+
 /// Prints out the name of the last scheme applied
 pub fn current(data_path: &Path, property_name: &str) -> Result<()> {
-    let current_scheme_slug =
-        fs::read_to_string(data_path.join(CURRENT_SCHEME_FILE_NAME)).unwrap_or_default();
+    let current_scheme_slug = get_current_scheme_slug(data_path);
     let schemes_path = data_path.join(format!("{}/{}", REPO_DIR, SCHEMES_REPO_NAME));
 
     if current_scheme_slug.is_empty() {

--- a/src/operations/current.rs
+++ b/src/operations/current.rs
@@ -1,5 +1,6 @@
 use crate::constants::{
-    ARTIFACTS_DIR, CURRENT_SCHEME_FILE_NAME, CUSTOM_SCHEMES_DIR_NAME, REPO_DIR, REPO_NAME, SCHEMES_REPO_NAME
+    ARTIFACTS_DIR, CURRENT_SCHEME_FILE_NAME, CUSTOM_SCHEMES_DIR_NAME, REPO_DIR, REPO_NAME,
+    SCHEMES_REPO_NAME,
 };
 use anyhow::{anyhow, Result};
 use std::fs;
@@ -7,7 +8,8 @@ use std::path::Path;
 use tinted_builder_rust::utils::get_scheme_files;
 
 pub fn get_current_scheme_slug(data_path: &Path) -> String {
-    fs::read_to_string(data_path.join(ARTIFACTS_DIR).join(CURRENT_SCHEME_FILE_NAME)).unwrap_or_default()
+    fs::read_to_string(data_path.join(ARTIFACTS_DIR).join(CURRENT_SCHEME_FILE_NAME))
+        .unwrap_or_default()
 }
 
 /// Prints out the name of the last scheme applied

--- a/src/operations/current.rs
+++ b/src/operations/current.rs
@@ -1,5 +1,5 @@
 use crate::constants::{
-    CURRENT_SCHEME_FILE_NAME, CUSTOM_SCHEMES_DIR_NAME, REPO_DIR, REPO_NAME, SCHEMES_REPO_NAME,
+    ARTIFACTS_DIR, CURRENT_SCHEME_FILE_NAME, CUSTOM_SCHEMES_DIR_NAME, REPO_DIR, REPO_NAME, SCHEMES_REPO_NAME
 };
 use anyhow::{anyhow, Result};
 use std::fs;
@@ -7,7 +7,7 @@ use std::path::Path;
 use tinted_builder_rust::utils::get_scheme_files;
 
 pub fn get_current_scheme_slug(data_path: &Path) -> String {
-    fs::read_to_string(data_path.join(CURRENT_SCHEME_FILE_NAME)).unwrap_or_default()
+    fs::read_to_string(data_path.join(ARTIFACTS_DIR).join(CURRENT_SCHEME_FILE_NAME)).unwrap_or_default()
 }
 
 /// Prints out the name of the last scheme applied

--- a/src/operations/cycle.rs
+++ b/src/operations/cycle.rs
@@ -1,0 +1,56 @@
+use crate::config::Config;
+use anyhow::Result;
+use std::path::Path;
+use crate::operations::current::get_current_scheme_slug;
+use crate::operations::apply::apply;
+
+/// Cycle to next preferred scheme
+pub fn cycle(
+    config_path: &Path,
+    data_path: &Path,
+    is_quiet: bool,
+    active_operation: Option<&str>,
+) -> Result<()> {
+
+    let config = Config::read(config_path)?;
+
+    let current_scheme_slug = get_current_scheme_slug(data_path);
+
+    // Figure out what the next theme should be given current theme & preferred schemes.
+    let next_theme = normalized_cycle(&config)
+        .as_ref()
+        .and_then(|vec| {
+            let next_index = vec.iter().position(|scheme| scheme == &current_scheme_slug)
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            Some(vec[(next_index) % vec.len()].clone())
+        })
+        .unwrap_or(current_scheme_slug);
+
+    if !is_quiet {
+        println!("Switching to next theme in cycle: {}", next_theme);
+    }
+
+    apply(config_path, data_path, &next_theme, is_quiet, active_operation)
+}
+
+fn normalized_cycle(config: &Config) -> Option<Vec<String>> {
+    // Return a list of preferred schemes based on presence of this value in the config, and
+    // whatever the default scheme is if specified in config also.
+    config.preferred_schemes.as_ref().map(|preferred| {
+        // If default scheme is defined, add it to the cycle.
+        config
+            .default_scheme
+            .as_ref()
+            .filter(|default| !preferred.contains(default))
+            .map(|default| {
+                let mut result = vec![default.clone()];
+                result.extend(preferred.clone());
+                result
+            })
+            .unwrap_or_else(|| preferred.clone())
+    }).or_else(|| {
+        // If default scheme is defined, use it if preferred schemes is unset.
+        config.default_scheme.as_ref().map(|theme| vec![theme.clone()])
+    })
+}

--- a/src/operations/cycle.rs
+++ b/src/operations/cycle.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::utils::{next_scheme_in_cycle, user_curated_scheme_list};
 use anyhow::Result;
 use std::path::Path;
 use crate::operations::current::get_current_scheme_slug;
@@ -17,40 +18,17 @@ pub fn cycle(
     let current_scheme_slug = get_current_scheme_slug(data_path);
 
     // Figure out what the next theme should be given current theme & preferred schemes.
-    let next_theme = normalized_cycle(&config)
+    let next_theme = user_curated_scheme_list(&config)
         .as_ref()
-        .and_then(|vec| {
-            let next_index = vec.iter().position(|scheme| scheme == &current_scheme_slug)
-                .map(|i| i + 1)
-                .unwrap_or(0);
-            Some(vec[(next_index) % vec.len()].clone())
+        .map(|vec| {
+            next_scheme_in_cycle(&current_scheme_slug, vec.to_vec())
         })
         .unwrap_or(current_scheme_slug);
 
     if !is_quiet {
-        println!("Switching to next theme in cycle: {}", next_theme);
+        println!("Applying next theme in cycle: {}", next_theme);
     }
 
     apply(config_path, data_path, &next_theme, is_quiet, active_operation)
 }
 
-fn normalized_cycle(config: &Config) -> Option<Vec<String>> {
-    // Return a list of preferred schemes based on presence of this value in the config, and
-    // whatever the default scheme is if specified in config also.
-    config.preferred_schemes.as_ref().map(|preferred| {
-        // If default scheme is defined, add it to the cycle.
-        config
-            .default_scheme
-            .as_ref()
-            .filter(|default| !preferred.contains(default))
-            .map(|default| {
-                let mut result = vec![default.clone()];
-                result.extend(preferred.clone());
-                result
-            })
-            .unwrap_or_else(|| preferred.clone())
-    }).or_else(|| {
-        // If default scheme is defined, use it if preferred schemes is unset.
-        config.default_scheme.as_ref().map(|theme| vec![theme.clone()])
-    })
-}

--- a/src/operations/cycle.rs
+++ b/src/operations/cycle.rs
@@ -1,9 +1,9 @@
 use crate::config::Config;
+use crate::operations::apply::apply;
+use crate::operations::current::get_current_scheme_slug;
 use crate::utils::{next_scheme_in_cycle, user_curated_scheme_list};
 use anyhow::Result;
 use std::path::Path;
-use crate::operations::current::get_current_scheme_slug;
-use crate::operations::apply::apply;
 
 /// Cycle to next preferred scheme
 pub fn cycle(
@@ -12,7 +12,6 @@ pub fn cycle(
     is_quiet: bool,
     active_operation: Option<&str>,
 ) -> Result<()> {
-
     let config = Config::read(config_path)?;
 
     let current_scheme_slug = get_current_scheme_slug(data_path);
@@ -20,15 +19,18 @@ pub fn cycle(
     // Figure out what the next theme should be given current theme & preferred schemes.
     let next_theme = user_curated_scheme_list(&config)
         .as_ref()
-        .map(|vec| {
-            next_scheme_in_cycle(&current_scheme_slug, vec.to_vec())
-        })
+        .map(|vec| next_scheme_in_cycle(&current_scheme_slug, vec.to_vec()))
         .unwrap_or(current_scheme_slug);
 
     if !is_quiet {
         println!("Applying next theme in cycle: {}", next_theme);
     }
 
-    apply(config_path, data_path, &next_theme, is_quiet, active_operation)
+    apply(
+        config_path,
+        data_path,
+        &next_theme,
+        is_quiet,
+        active_operation,
+    )
 }
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -435,7 +435,9 @@ pub fn replace_tilde_slash_with_home(path_str: &str) -> Result<PathBuf> {
 }
 
 pub fn next_scheme_in_cycle(current: &String, schemes: Vec<String>) -> String {
-    let next_index = schemes.iter().position(|scheme| scheme == current)
+    let next_index = schemes
+        .iter()
+        .position(|scheme| scheme == current)
         .map(|i| i + 1)
         .unwrap_or(0);
     schemes[(next_index) % schemes.len()].clone()
@@ -444,20 +446,27 @@ pub fn next_scheme_in_cycle(current: &String, schemes: Vec<String>) -> String {
 pub fn user_curated_scheme_list(config: &Config) -> Option<Vec<String>> {
     // Return a list of preferred schemes based on presence of this value in the config, and
     // whatever the default scheme is if specified in config also.
-    config.preferred_schemes.as_ref().map(|preferred| {
-        // If default scheme is defined, add it to the cycle.
-        config
-            .default_scheme
-            .as_ref()
-            .filter(|default| !preferred.contains(default))
-            .map(|default| {
-                let mut result = vec![default.clone()];
-                result.extend(preferred.clone());
-                result
-            })
-            .unwrap_or_else(|| preferred.clone())
-    }).or_else(|| {
-        // If default scheme is defined, use it if preferred schemes is unset.
-        config.default_scheme.as_ref().map(|theme| vec![theme.clone()])
-    })
+    config
+        .preferred_schemes
+        .as_ref()
+        .map(|preferred| {
+            // If default scheme is defined, add it to the cycle.
+            config
+                .default_scheme
+                .as_ref()
+                .filter(|default| !preferred.contains(default))
+                .map(|default| {
+                    let mut result = vec![default.clone()];
+                    result.extend(preferred.clone());
+                    result
+                })
+                .unwrap_or_else(|| preferred.clone())
+        })
+        .or_else(|| {
+            // If default scheme is defined, use it if preferred schemes is unset.
+            config
+                .default_scheme
+                .as_ref()
+                .map(|theme| vec![theme.clone()])
+        })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -433,3 +433,31 @@ pub fn replace_tilde_slash_with_home(path_str: &str) -> Result<PathBuf> {
         Ok(PathBuf::from(trimmed_path_str))
     }
 }
+
+pub fn next_scheme_in_cycle(current: &String, schemes: Vec<String>) -> String {
+    let next_index = schemes.iter().position(|scheme| scheme == current)
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    schemes[(next_index) % schemes.len()].clone()
+}
+
+pub fn user_curated_scheme_list(config: &Config) -> Option<Vec<String>> {
+    // Return a list of preferred schemes based on presence of this value in the config, and
+    // whatever the default scheme is if specified in config also.
+    config.preferred_schemes.as_ref().map(|preferred| {
+        // If default scheme is defined, add it to the cycle.
+        config
+            .default_scheme
+            .as_ref()
+            .filter(|default| !preferred.contains(default))
+            .map(|default| {
+                let mut result = vec![default.clone()];
+                result.extend(preferred.clone());
+                result
+            })
+            .unwrap_or_else(|| preferred.clone())
+    }).or_else(|| {
+        // If default scheme is defined, use it if preferred schemes is unset.
+        config.default_scheme.as_ref().map(|theme| vec![theme.clone()])
+    })
+}

--- a/tests/cli_current_subcommand_tests.rs
+++ b/tests/cli_current_subcommand_tests.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use anyhow::Result;
 use utils::{
-    copy_dir_all, setup, write_to_file, CURRENT_SCHEME_FILE_NAME, REPO_DIR, SCHEMES_REPO_NAME,
+    copy_dir_all, setup, write_to_file, ARTIFACTS_DIR, CURRENT_SCHEME_FILE_NAME, REPO_DIR, SCHEMES_REPO_NAME
 };
 
 #[test]
@@ -107,7 +107,7 @@ where
     )?;
 
     let scheme_name = "base16-tinty-generated";
-    let current_scheme_path = data_path.join(CURRENT_SCHEME_FILE_NAME);
+    let current_scheme_path = data_path.join(ARTIFACTS_DIR).join(CURRENT_SCHEME_FILE_NAME);
     let schemes_dir = data_path.join(format!("{}/{}", REPO_DIR, SCHEMES_REPO_NAME));
 
     write_to_file(&current_scheme_path, scheme_name)?;

--- a/tests/cli_current_subcommand_tests.rs
+++ b/tests/cli_current_subcommand_tests.rs
@@ -2,7 +2,8 @@ mod utils;
 
 use anyhow::Result;
 use utils::{
-    copy_dir_all, setup, write_to_file, ARTIFACTS_DIR, CURRENT_SCHEME_FILE_NAME, REPO_DIR, SCHEMES_REPO_NAME
+    copy_dir_all, setup, write_to_file, ARTIFACTS_DIR, CURRENT_SCHEME_FILE_NAME, REPO_DIR,
+    SCHEMES_REPO_NAME,
 };
 
 #[test]

--- a/tests/cli_current_subcommand_tests.rs
+++ b/tests/cli_current_subcommand_tests.rs
@@ -14,7 +14,7 @@ fn test_cli_current_subcommand_with_setup() -> Result<()> {
     let (_, data_path, command_vec, cleanup) =
         setup("test_cli_current_subcommand_with_setup", "current")?;
     let scheme_name = "base16-oceanicnext";
-    let current_scheme_path = data_path.join(CURRENT_SCHEME_FILE_NAME);
+    let current_scheme_path = data_path.join(ARTIFACTS_DIR).join(CURRENT_SCHEME_FILE_NAME);
     let schemes_dir = data_path.join(format!("{}/{}", REPO_DIR, SCHEMES_REPO_NAME));
 
     write_to_file(&current_scheme_path, scheme_name)?;

--- a/tests/cli_cycle_subcommand_tests.rs
+++ b/tests/cli_cycle_subcommand_tests.rs
@@ -1,0 +1,339 @@
+mod utils;
+
+use std::fs;
+use std::path::Path;
+
+use crate::utils::{setup, write_to_file, CURRENT_SCHEME_FILE_NAME, REPO_NAME};
+use anyhow::Result;
+use utils::build_comamnd_vec;
+
+#[test]
+fn test_cli_cycle_subcommand_with_default_scheme_only() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let scheme_name = "base16-oceanicnext";
+    let (config_path, data_path, apply_command_vec, cleanup) = setup(
+        "test_cli_cycle_subcommand_with_default_scheme_only",
+        format!("apply {}", &scheme_name).as_str(),
+    )?;
+    let config_content = r##"
+default-scheme = "base16-github"
+"##;
+    write_to_file(&config_path, config_content)?;
+
+    // ---
+    // Act
+    // ---
+    utils::run_install_command(&config_path, &data_path)?;
+    let (_, apply_stderr) = utils::run_command(apply_command_vec).unwrap();
+
+    let (cycle_stdout, cycle_stderr) = utils::run_command(build_comamnd_vec(
+        "cycle",
+        config_path.as_path(),
+        data_path.as_path(),
+    )?)
+    .unwrap();
+
+    // ------
+    // Assert
+    // ------
+    assert!(
+        apply_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+    assert_eq!(
+        cycle_stdout,
+        "Applying next theme in cycle: base16-github\n"
+    );
+    assert!(
+        cycle_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+
+    cleanup()?;
+    Ok(())
+}
+
+#[test]
+fn test_cli_cycle_subcommand_with_preferred_schemes() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let scheme_name = "base16-oceanicnext";
+    let (config_path, data_path, apply_command_vec, cleanup) = setup(
+        "test_cli_cycle_subcommand_with_default_scheme_only",
+        format!("apply {}", &scheme_name).as_str(),
+    )?;
+    let config_content = r##"
+preferred-schemes = ["base24-github", "base24-zenburn", "base24-ubuntu"]
+"##;
+    write_to_file(&config_path, config_content)?;
+
+    // ---
+    // Act
+    // ---
+    utils::run_install_command(&config_path, &data_path)?;
+    let (_, apply_stderr) = utils::run_command(apply_command_vec).unwrap();
+
+    let (cycle1_stdout, cycle1_stderr) = utils::run_command(build_comamnd_vec(
+        "cycle",
+        config_path.as_path(),
+        data_path.as_path(),
+    )?)
+    .unwrap();
+
+
+
+    // ------
+    // Assert
+    // ------
+    assert!(
+        apply_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+    assert_eq!(
+        cycle1_stdout,
+        "Applying next theme in cycle: base24-github\n"
+    );
+    assert!(
+        cycle1_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+
+    let (cycle2_stdout, cycle2_stderr) = utils::run_command(build_comamnd_vec(
+        "cycle",
+        config_path.as_path(),
+        data_path.as_path(),
+    )?)
+    .unwrap();
+
+    assert_eq!(
+        cycle2_stdout,
+        "Applying next theme in cycle: base24-zenburn\n"
+    );
+    assert!(
+        cycle2_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+    let (cycle3_stdout, cycle3_stderr) = utils::run_command(build_comamnd_vec(
+        "cycle",
+        config_path.as_path(),
+        data_path.as_path(),
+    )?)
+    .unwrap();
+
+    assert_eq!(
+        cycle3_stdout,
+        "Applying next theme in cycle: base24-ubuntu\n"
+    );
+    assert!(
+        cycle3_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+
+    cleanup()?;
+    Ok(())
+}
+
+#[test]
+fn test_cli_cycle_subcommand_correct_next_scheme() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let scheme_name = "base24-zenburn";
+    let (config_path, data_path, apply_command_vec, cleanup) = setup(
+        "test_cli_cycle_subcommand_with_default_scheme_only",
+        format!("apply {}", &scheme_name).as_str(),
+    )?;
+    let config_content = r##"
+preferred-schemes = ["base24-github", "base24-zenburn", "base24-ubuntu"]
+"##;
+    write_to_file(&config_path, config_content)?;
+
+    // ---
+    // Act
+    // ---
+    utils::run_install_command(&config_path, &data_path)?;
+    let (_, apply_stderr) = utils::run_command(apply_command_vec).unwrap();
+
+    let (cycle_stdout, cycle_stderr) = utils::run_command(build_comamnd_vec(
+        "cycle",
+        config_path.as_path(),
+        data_path.as_path(),
+    )?)
+    .unwrap();
+
+
+
+    // ------
+    // Assert
+    // ------
+    assert!(
+        apply_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+    assert_eq!(
+        cycle_stdout,
+        "Applying next theme in cycle: base24-ubuntu\n"
+    );
+    assert!(
+        cycle_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+
+    cleanup()?;
+    Ok(())
+}
+
+#[test]
+fn test_cli_cycle_subcommand_wraps_around() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let scheme_name = "base24-ubuntu";
+    let (config_path, data_path, apply_command_vec, cleanup) = setup(
+        "test_cli_cycle_subcommand_with_default_scheme_only",
+        format!("apply {}", &scheme_name).as_str(),
+    )?;
+    let config_content = r##"
+preferred-schemes = ["base24-github", "base24-zenburn", "base24-ubuntu"]
+"##;
+    write_to_file(&config_path, config_content)?;
+
+    // ---
+    // Act
+    // ---
+    utils::run_install_command(&config_path, &data_path)?;
+    let (_, apply_stderr) = utils::run_command(apply_command_vec).unwrap();
+
+    let (cycle_stdout, cycle_stderr) = utils::run_command(build_comamnd_vec(
+        "cycle",
+        config_path.as_path(),
+        data_path.as_path(),
+    )?)
+    .unwrap();
+
+
+
+    // ------
+    // Assert
+    // ------
+    assert!(
+        apply_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+    assert_eq!(
+        cycle_stdout,
+        "Applying next theme in cycle: base24-github\n"
+    );
+    assert!(
+        cycle_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+
+    cleanup()?;
+    Ok(())
+}
+
+#[test]
+fn test_cli_cycle_subcommand_default_scheme_prepended_to_cycle() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let scheme_name = "base16-oceanicnext";
+    let (config_path, data_path, apply_command_vec, cleanup) = setup(
+        "test_cli_cycle_subcommand_with_default_scheme_only",
+        format!("apply {}", &scheme_name).as_str(),
+    )?;
+    let config_content = r##"
+default-scheme = "base24-github"
+preferred-schemes = ["base24-zenburn", "base24-ubuntu"]
+"##;
+    write_to_file(&config_path, config_content)?;
+
+    // ---
+    // Act
+    // ---
+    utils::run_install_command(&config_path, &data_path)?;
+    let (_, apply_stderr) = utils::run_command(apply_command_vec).unwrap();
+
+    let (cycle_stdout, cycle_stderr) = utils::run_command(build_comamnd_vec(
+        "cycle",
+        config_path.as_path(),
+        data_path.as_path(),
+    )?)
+    .unwrap();
+
+
+
+    // ------
+    // Assert
+    // ------
+    assert!(
+        apply_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+    assert_eq!(
+        cycle_stdout,
+        "Applying next theme in cycle: base24-github\n"
+    );
+    assert!(
+        cycle_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+
+    cleanup()?;
+    Ok(())
+}
+
+#[test]
+fn test_cli_cycle_subcommand_default_scheme_not_duplicated_in_cycle() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let scheme_name = "base16-oceanicnext";
+    let (config_path, data_path, apply_command_vec, cleanup) = setup(
+        "test_cli_cycle_subcommand_with_default_scheme_only",
+        format!("apply {}", &scheme_name).as_str(),
+    )?;
+    let config_content = r##"
+default-scheme = "base24-github"
+preferred-schemes = ["base24-zenburn", "base24-github", "base24-ubuntu"]
+"##;
+    write_to_file(&config_path, config_content)?;
+
+    // ---
+    // Act
+    // ---
+    utils::run_install_command(&config_path, &data_path)?;
+    let (_, apply_stderr) = utils::run_command(apply_command_vec).unwrap();
+
+    let (cycle_stdout, cycle_stderr) = utils::run_command(build_comamnd_vec(
+        "cycle",
+        config_path.as_path(),
+        data_path.as_path(),
+    )?)
+    .unwrap();
+
+
+
+    // ------
+    // Assert
+    // ------
+    assert!(
+        apply_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+    assert_eq!(
+        cycle_stdout,
+        "Applying next theme in cycle: base24-zenburn\n"
+    );
+    assert!(
+        cycle_stderr.is_empty(),
+        "stderr does not contain the expected output"
+    );
+
+    cleanup()?;
+    Ok(())
+}

--- a/tests/cli_cycle_subcommand_tests.rs
+++ b/tests/cli_cycle_subcommand_tests.rs
@@ -59,7 +59,7 @@ fn test_cli_cycle_subcommand_with_preferred_schemes() -> Result<()> {
     // -------
     let scheme_name = "base16-oceanicnext";
     let (config_path, data_path, apply_command_vec, cleanup) = setup(
-        "test_cli_cycle_subcommand_with_default_scheme_only",
+        "test_cli_cycle_subcommand_with_preferred_schemes",
         format!("apply {}", &scheme_name).as_str(),
     )?;
     let config_content = r##"
@@ -186,7 +186,7 @@ fn test_cli_cycle_subcommand_wraps_around() -> Result<()> {
     // -------
     let scheme_name = "base24-ubuntu";
     let (config_path, data_path, apply_command_vec, cleanup) = setup(
-        "test_cli_cycle_subcommand_with_default_scheme_only",
+        "test_cli_cycle_subcommand_wraps_around",
         format!("apply {}", &scheme_name).as_str(),
     )?;
     let config_content = r##"
@@ -234,7 +234,7 @@ fn test_cli_cycle_subcommand_default_scheme_prepended_to_cycle() -> Result<()> {
     // -------
     let scheme_name = "base16-oceanicnext";
     let (config_path, data_path, apply_command_vec, cleanup) = setup(
-        "test_cli_cycle_subcommand_with_default_scheme_only",
+        "test_cli_cycle_subcommand_default_scheme_prepended_to_cycle",
         format!("apply {}", &scheme_name).as_str(),
     )?;
     let config_content = r##"
@@ -283,7 +283,7 @@ fn test_cli_cycle_subcommand_default_scheme_not_duplicated_in_cycle() -> Result<
     // -------
     let scheme_name = "base16-oceanicnext";
     let (config_path, data_path, apply_command_vec, cleanup) = setup(
-        "test_cli_cycle_subcommand_with_default_scheme_only",
+        "test_cli_cycle_subcommand_default_scheme_not_duplicated_in_cycle",
         format!("apply {}", &scheme_name).as_str(),
     )?;
     let config_content = r##"

--- a/tests/cli_cycle_subcommand_tests.rs
+++ b/tests/cli_cycle_subcommand_tests.rs
@@ -1,9 +1,6 @@
 mod utils;
 
-use std::fs;
-use std::path::Path;
-
-use crate::utils::{setup, write_to_file, CURRENT_SCHEME_FILE_NAME, REPO_NAME};
+use crate::utils::{setup, write_to_file};
 use anyhow::Result;
 use utils::build_comamnd_vec;
 
@@ -82,8 +79,6 @@ preferred-schemes = ["base24-github", "base24-zenburn", "base24-ubuntu"]
         data_path.as_path(),
     )?)
     .unwrap();
-
-
 
     // ------
     // Assert
@@ -164,8 +159,6 @@ preferred-schemes = ["base24-github", "base24-zenburn", "base24-ubuntu"]
     )?)
     .unwrap();
 
-
-
     // ------
     // Assert
     // ------
@@ -213,8 +206,6 @@ preferred-schemes = ["base24-github", "base24-zenburn", "base24-ubuntu"]
         data_path.as_path(),
     )?)
     .unwrap();
-
-
 
     // ------
     // Assert
@@ -265,8 +256,6 @@ preferred-schemes = ["base24-zenburn", "base24-ubuntu"]
     )?)
     .unwrap();
 
-
-
     // ------
     // Assert
     // ------
@@ -315,8 +304,6 @@ preferred-schemes = ["base24-zenburn", "base24-github", "base24-ubuntu"]
         data_path.as_path(),
     )?)
     .unwrap();
-
-
 
     // ------
     // Assert

--- a/tests/cli_cycle_subcommand_tests.rs
+++ b/tests/cli_cycle_subcommand_tests.rs
@@ -138,7 +138,7 @@ fn test_cli_cycle_subcommand_correct_next_scheme() -> Result<()> {
     // -------
     let scheme_name = "base24-zenburn";
     let (config_path, data_path, apply_command_vec, cleanup) = setup(
-        "test_cli_cycle_subcommand_with_default_scheme_only",
+        "test_cli_cycle_subcommand_correct_next_scheme",
         format!("apply {}", &scheme_name).as_str(),
     )?;
     let config_content = r##"

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -99,14 +99,8 @@ pub fn setup(
 )> {
     let config_path = PathBuf::from(format!("config_path_{}.toml", name).as_str());
     let data_path = PathBuf::from(format!("data_path_{}", name).as_str());
-    let command = format!(
-        "{} --config=\"{}\" --data-dir=\"{}\" {}",
-        COMMAND_NAME,
-        config_path.display(),
-        data_path.display(),
-        command
-    );
-    let command_vec = shell_words::split(command.as_str()).map_err(anyhow::Error::new)?;
+
+    let command_vec = build_comamnd_vec(command, &config_path, &data_path)?;
 
     cleanup(&config_path, &data_path)?;
     write_to_file(&config_path, "")?;
@@ -120,6 +114,22 @@ pub fn setup(
         command_vec,
         Box::new(move || cleanup(&config_path_clone, &data_path_clone)),
     ))
+}
+
+#[allow(clippy::type_complexity)]
+pub fn build_comamnd_vec(
+    command: &str,
+    config_path: &Path,
+    data_path: &Path
+) -> Result<Vec<String>> {
+    let command = format!(
+        "{} --config=\"{}\" --data-dir=\"{}\" {}",
+        COMMAND_NAME,
+        config_path.display(),
+        data_path.display(),
+        command
+    );
+    shell_words::split(command.as_str()).map_err(anyhow::Error::new)
 }
 
 #[allow(dead_code)]
@@ -139,3 +149,4 @@ pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> 
     }
     Ok(())
 }
+

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -120,7 +120,7 @@ pub fn setup(
 pub fn build_comamnd_vec(
     command: &str,
     config_path: &Path,
-    data_path: &Path
+    data_path: &Path,
 ) -> Result<Vec<String>> {
     let command = format!(
         "{} --config=\"{}\" --data-dir=\"{}\" {}",
@@ -149,4 +149,3 @@ pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> 
     }
     Ok(())
 }
-


### PR DESCRIPTION
@JamyGolden What do you think of a feature like this?

The most common use-case by far I use Tinty for is switching between a couple of dark and light themes, and I think this is probably true for others. I thought it would be convenient if there was a way to quickly apply one's favorite themes by cycling through a small list the user curated (e.g. one light, one dark)

This PR does this by:

1. Checking the config what the preferred themes are.
2. Resolves what the next theme should be.
3. Consider cases where `default-scheme` is set.
4. Available as `tinty cycle`.

Let me know what you think.

### Todos

- [x] Tests
- [x] Changelog
- [x] README