### PR TITLE
Fix test which directly depends on scheme count

### DIFF
--- a/tests/cli_list_subcommand_tests.rs
+++ b/tests/cli_list_subcommand_tests.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use tinted_builder::{SchemeSystem, SchemeVariant};
 use utils::setup;
 
-const SCHEME_COUNT: usize = 447;
+const SCHEME_COUNT: usize = 459;
 
 #[test]
 fn test_cli_list_subcommand_without_setup() -> Result<()> {
@@ -447,7 +447,7 @@ fn test_cli_list_subcommand_as_json_with_setup() -> Result<()> {
     let results: Vec<TestSchemeEntry> = serde_json::from_str(&stdout).unwrap();
 
     assert!(
-        results.len() == SCHEME_COUNT,
+        results.len() >= SCHEME_COUNT,
         "expected JSON to contain {} entries, found {}",
         SCHEME_COUNT,
         results.len()


### PR DESCRIPTION
`cargo test` is failing on main due to:

```
 ---- test_cli_list_subcommand_as_json_with_setup stdout ----

thread 'test_cli_list_subcommand_as_json_with_setup' panicked at tests/cli_list_subcommand_tests.rs:449:5:
expected JSON to contain 447 entries, found 459
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::ops::function::FnOnce::call_once
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This is brittle since it will break when `SCHEMES_COUNT` is compared to a value that will be increased at some point.

This change the test to ensure the scheme-results count is `>=` `SCHEMES_COUNT`.