### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/workflows/create-release-commit.yml
+++ b/.github/workflows/create-release-commit.yml
@@ -5,9 +5,9 @@
 # - ./Cargo.lock
 # - ./THIRD-PARTY-LICENSES.md
 # - ./CHANGELOG.md
-name: "Release Commit"
+name: "Create Release-Commit"
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       bump_level:
         description: "What type of release is this?"
@@ -16,6 +16,10 @@ on:
         options:
           - minor
           - patch
+    secrets:
+      BOT_ACCESS_TOKEN:
+        description: GitHub bot access token
+        required: true
 permissions:
   contents: write
 
@@ -40,7 +44,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
 
       - name: Install cargo about and cargo deny for create_release_changes script
         run: |

--- a/.github/workflows/create-release-git-tag.yml
+++ b/.github/workflows/create-release-git-tag.yml
@@ -1,4 +1,4 @@
-name: Tag release
+name: Create Release-Commit Git Tag
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,14 @@
 name: Release
 on:
   workflow_dispatch:
+    inputs:
+      bump_level:
+        description: "What type of release is this? (Probably 'minor')"
+        required: true
+        type: choice
+        options:
+          - minor
+          - patch
 env:
   CARGO_INCREMENTAL: 0
 permissions:
@@ -22,21 +30,28 @@ jobs:
     with:
       cache-key: ${{ needs.setup-environment.outputs.cargo_cache_key }}
 
-  tag-release:
+  create-release-commit:
     needs:
-      - setup-environment
       - lint
       - test
-    uses: ./.github/workflows/tag-release.yml
+    uses: ./.github/workflows/release-commit.yml
+    with:
+      bump_level: ${{ github.event.inputs.bump_level }}
+    secrets:
+      BOT_ACCESS_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN }}
+
+  create-release-git-tag:
+    needs:
+      - create-release-commit
+    uses: ./.github/workflows/create-release-git-tag.yml
     with:
       git_tag_name: ${{ needs.setup-environment.outputs.git_tag_name }}
     secrets:
       RELEASE: ${{ secrets.RELEASE }}
 
-  create-release:
-    needs: 
-      - setup-environment
-      - tag-release
+  create-github-release:
+    needs:
+      - create-release-git-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,10 +61,9 @@ jobs:
           changelog: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  release:
+  create-binaries:
     needs:
-      - setup-environment
-      - create-release
+      - create-github-release
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -82,7 +96,7 @@ jobs:
           checksum: sha256
 
   publish-crate:
-    needs: release
+    needs: create-binaries
     uses: ./.github/workflows/publish-crate.yml
     secrets:
       CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release process
 
 1. Make sure `## Unreleased` section exists in [CHANGELOG.md]
-1. Run [Release Commit GitHub action]. Select `minor` or `patch` as a
+1. Run [Release GitHub action]. Select `minor` or `patch` as a
    dispatch value option. This follows the [semver] pattern.
 
    - `minor` if changes include new features or breaking changes
@@ -12,11 +12,8 @@
    1. Bumps `Cargo.toml` version by `minor` or `patch`
    1. Updates `Cargo.lock` with the new version
    1. Updates [CHANGELOG.md] `## Unreleased` section to the new version
-   1. Updates [LICENSE-THIRD-PARTY.md]
-
-1. Once the CI tests have passed, run the [Release GitHub action]. This
-   will automatically do the following:
-
+   1. Regenerates [LICENSE-THIRD-PARTY.md] using `cargo-about` for dependency
+      license summaries
    1. Add a Git tag to the release commit with the new
       version number
    1. Create a release under [GitHub releases] with the changes
@@ -27,10 +24,27 @@
    action] and specify `tinty` as the action input value. This will
    update the version for [Homebrew]
 
+## Debugging
+
+Have a look at which step has failed and read the logs to understand what went
+wrong.
+
+1. If the problem is before the `Tag Release` step
+   1. Push a fix for the problem
+   1. Re-run the [Release GitHub action] workflow.
+1. If the problem is with or after the `Tag Release` step
+   1. Remove the git tag with `git push --delete origin v0.x.x` (where `0.x.x`
+      mirrors the Cargo version number)
+   1. Push a fix for the problem
+   1. Individually run the `Tag Release` workflow
+   1. Individually run the workflows following the `Tag Release` workflow. This
+      is required because the `Create Release-Commit` action has already
+      created the commit, since we can't remove that commit we need to manually
+      trigger the subsequent workflows.
+
 [semver]: https://semver.org/
 [CHANGELOG.md]: ./CHANGELOG.md
 [LICENSE-THIRD-PARTY.md]: ./LICENSE-THIRD-PARTY.md
-[Release Commit GitHub action]: https://github.com/tinted-theming/tinty/actions/workflows/release-commit.yml
 [Release GitHub action]: https://github.com/tinted-theming/tinty/actions/workflows/release.yml
 [GitHub releases]: https://github.com/tinted-theming/tinty/releases
 [homebrew-tinted]: https://github.com/tinted-theming/homebrew-tinted


### PR DESCRIPTION
Consolidate two release steps into 1 for simplicity. The idea is someone can just run the `Release` workflow and everything is great. I've added some debugging steps in RELEASE.md.

PR should be ok, still in draft though since workflows are always a pain to get right so I want to look at it more and get any suggestions/comments from you @bezhermoso 