### PR TITLE
Update usage instructions to source hooks

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -109,7 +109,7 @@ tinty_source_shell_theme() {
     while read -r script; do
       # shellcheck disable=SC1090
       . "$script"
-    done < <(find "$tinty_data_dir" -maxdepth 1 -type f -name "*.sh" -newer "$newer_file")
+    done < <(find "$tinty_data_dir" -maxdepth 1 -type l -name "*.sh" -newer "$newer_file")
 
     unset tinty_data_dir
   fi

--- a/USAGE.md
+++ b/USAGE.md
@@ -109,7 +109,7 @@ tinty_source_shell_theme() {
     while read -r script; do
       # shellcheck disable=SC1090
       . "$script"
-    done < <(find "$tinty_data_dir" -maxdepth 1 -type l -name "*.sh" -newer "$newer_file")
+    done < <(find "$tinty_data_dir" -maxdepth 1 -type f -o -type l -name "*.sh" -newer "$newer_file")
 
     unset tinty_data_dir
   fi


### PR DESCRIPTION
## Description

The usage instructions to source hook scripts to allow setting env vars search for `*.sh` files, but those scripts are actually symbolic links, thus the `find` command never fins any and the function does not work.

by replacing `-type f` with `-type l` the function works.

### Alternative script

I myself simplify this script by simply redefining the `tinty`  command with a function, so there is no need for the alias:

```bash
tinty() {
  newer_file=$(mktemp)
  command tinty $@
  subcommand="$1"

  if [ "$subcommand" = "apply" ] || [ "$subcommand" = "init" ]; then
    tinty_data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tinted-theming/tinty"

    while read -r script; do
      # shellcheck disable=SC1090
      . "$script"
    done < <(find "$tinty_data_dir" -maxdepth 1 -type l -name "*.sh" -newer "$newer_file")

    unset tinty_data_dir
  fi

  unset subcommand
}
```