### PR TITLE
feat(config): define JSON-Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 - Add `[[rings]]` config option to define named lists of schemes for `tinty cycle`
   to cycle through, along with a `default-cycle-ring` config option and a
   `--ring` flag on `tinty cycle` to select which ring to use.
+- Add `config.schema.json`, a JSON Schema describing the `config.toml` format.
+  Editors using a TOML language server with JSON Schema support (e.g. taplo via
+  Even Better TOML, Helix, Neovim, Zed) can use it for key autocomplete, hover
+  docs, and inline validation by adding a `#:schema` directive at the top of
+  their config or referencing it via [SchemaStore](https://www.schemastore.org/).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add `[[rings]]` config option to define named lists of schemes for `tinty cycle`
   to cycle through, along with a `default-cycle-ring` config option and a
   `--ring` flag on `tinty cycle` to select which ring to use.
-- Add `config.schema.json`, a JSON Schema describing the `config.toml` format.
+- Add `schemas/config.schema.json`, a JSON Schema describing the `config.toml` format.
   Editors using a TOML language server with JSON Schema support (e.g. taplo via
   Even Better TOML, Helix, Neovim, Zed) can use it for key autocomplete, hover
   docs, and inline validation by adding a `#:schema` directive at the top of

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tinted-theming/tinty/blob/main/config.schema.json",
+  "title": "Tinty configuration",
+  "description": "Schema for Tinty's config.toml. The file lives at $XDG_CONFIG_HOME/tinted-theming/tinty/config.toml (or ~/.config/tinted-theming/tinty/config.toml) by default, and may be overridden with --config/-c.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "shell": {
+      "type": "string",
+      "description": "Shell command used to execute hooks. Must contain the '{}' command placeholder, which is substituted with the hook command at runtime.",
+      "default": "sh -c '{}'",
+      "pattern": "\\{\\}",
+      "examples": ["sh -c '{}'", "bash -c '{}'", "zsh -c '{}'"]
+    },
+    "default-scheme": {
+      "type": "string",
+      "description": "Scheme to apply when no scheme has been previously set. Used specifically by `tinty init`.",
+      "examples": ["base16-mocha", "base16-oceanicnext"]
+    },
+    "preferred-schemes": {
+      "type": "array",
+      "description": "Ordered list of favourite schemes that `tinty cycle` rotates through.",
+      "items": { "type": "string" },
+      "default": [],
+      "examples": [["base16-gruvbox-dark", "base16-gruvbox-light"]]
+    },
+    "hooks": {
+      "type": "array",
+      "description": "Commands executed (through `shell`) after every `tinty apply`. The TINTY_* environment variables documented in the README are available to each command.",
+      "items": { "type": "string" },
+      "examples": [["echo \"The current scheme is: $(tinty current)\""]]
+    },
+    "items": {
+      "type": "array",
+      "description": "Themeable components. Each item ties a theme template repository to local output. If omitted, Tinty falls back to a single default item that themes tinted-shell.",
+      "items": { "$ref": "#/$defs/item" }
+    }
+  },
+  "$defs": {
+    "item": {
+      "type": "object",
+      "description": "A single themeable component, e.g. a terminal, editor, or status bar.",
+      "additionalProperties": false,
+      "required": ["name", "path", "themes-dir"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name for the item. Names must be unique across all items.",
+          "minLength": 1,
+          "examples": ["tinted-shell", "base16-vim", "tmux"]
+        },
+        "path": {
+          "type": "string",
+          "description": "URL of the theme template repository, an absolute filesystem path, or a path beginning with `~/` (which is expanded to the user's home directory).",
+          "minLength": 1,
+          "examples": [
+            "https://github.com/tinted-theming/tinted-shell",
+            "~/path/to/base16-tmux"
+          ]
+        },
+        "themes-dir": {
+          "type": "string",
+          "description": "Directory within the template repository that contains the theme files.",
+          "minLength": 1,
+          "examples": ["scripts", "colors", "themes"]
+        },
+        "hook": {
+          "type": "string",
+          "description": "Command executed (through `shell`) after the theme is applied. Useful for reloading the themed application's configuration. The TINTY_* environment variables documented in the README are available to the command; the deprecated %f / %n / %o printf-style placeholders also still work.",
+          "examples": [
+            ". %f",
+            "source \"$TINTY_THEME_FILE_PATH\"",
+            "test -n \"$TMUX\" && tmux source-file %f"
+          ]
+        },
+        "supported-systems": {
+          "type": "array",
+          "description": "Theming systems supported by the template. If a system is not listed it is assumed unsupported.",
+          "items": {
+            "type": "string",
+            "enum": ["base16", "base24", "tinted8"]
+          },
+          "uniqueItems": true,
+          "default": ["base16"]
+        },
+        "theme-file-extension": {
+          "type": "string",
+          "description": "Override for the theme file extension when the template's files do not match Tinty's default `base16-<name>.*` pattern.",
+          "examples": [".module.css"]
+        },
+        "revision": {
+          "type": "string",
+          "description": "Git revision (branch name, tag, or commit SHA) of the template repository to check out. Only meaningful when `path` is a Git URL.",
+          "default": "main",
+          "examples": ["main", "1.2.0", "a1b2c3d"]
+        },
+        "write-to-file": {
+          "type": "array",
+          "description": "Inline the rendered theme into an existing file rather than (or in addition to) producing a separate theme file. Tuple of [target_filename, start_marker?, end_marker?]: when the optional markers are provided, only content between them is replaced.",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "maxItems": 3,
+          "examples": [
+            ["~/.config/alacritty/config.toml", "# Tinty Start", "# Tinty End"]
+          ]
+        }
+      }
+    }
+  }
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -20,10 +20,22 @@
     },
     "preferred-schemes": {
       "type": "array",
-      "description": "Ordered list of favourite schemes that `tinty cycle` rotates through.",
+      "description": "Deprecated: replaced by `[[rings]]` + `default-cycle-ring`. `tinty cycle` will refuse to run while this key is present and will emit a migration message instructing how to convert these entries into a ring named \"default\".",
+      "deprecated": true,
       "items": { "type": "string" },
       "default": [],
       "examples": [["base16-gruvbox-dark", "base16-gruvbox-light"]]
+    },
+    "default-cycle-ring": {
+      "type": "string",
+      "description": "Name of the ring that `tinty cycle` uses when invoked without `--ring <name>`. Must match the `name` of one of the entries in `[[rings]]`.",
+      "minLength": 1,
+      "examples": ["default", "dark"]
+    },
+    "rings": {
+      "type": "array",
+      "description": "Named scheme cycles consumed by `tinty cycle`. Each ring is an ordered list of schemes; `tinty cycle` advances to the next entry in the active ring.",
+      "items": { "$ref": "#/$defs/ring" }
     },
     "hooks": {
       "type": "array",
@@ -38,6 +50,26 @@
     }
   },
   "$defs": {
+    "ring": {
+      "type": "object",
+      "description": "A named ordered cycle of schemes for `tinty cycle`.",
+      "additionalProperties": false,
+      "required": ["name", "schemes"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique, non-empty name for the ring. Used as the value of `--ring <name>` and `default-cycle-ring`.",
+          "minLength": 1,
+          "examples": ["default", "dark", "light"]
+        },
+        "schemes": {
+          "type": "array",
+          "description": "Ordered list of scheme IDs that `tinty cycle` rotates through for this ring.",
+          "items": { "type": "string" },
+          "examples": [["base16-gruvbox-dark", "base16-gruvbox-light", "base16-github-dark"]]
+        }
+      }
+    },
     "item": {
       "type": "object",
       "description": "A single themeable component, e.g. a terminal, editor, or status bar.",

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/tinted-theming/tinty/blob/main/config.schema.json",
+  "$id": "https://github.com/tinted-theming/tinty/blob/main/schemas/config.schema.json",
   "title": "Tinty configuration",
   "description": "Schema for Tinty's config.toml. The file lives at $XDG_CONFIG_HOME/tinted-theming/tinty/config.toml (or ~/.config/tinted-theming/tinty/config.toml) by default, and may be overridden with --config/-c.",
   "type": "object",


### PR DESCRIPTION
☝️ Just as title says, define a JSON-Schema describing the configuration options. This can be used to validate configuration files as well as provide niceties when viewing and/or editing the configuration files in editors that support it.