### PR TITLE
feat(gallery): Tinted8 detail-sheet variable panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
   Even Better TOML, Helix, Neovim, Zed) can use it for key autocomplete, hover
   docs, and inline validation by adding a `#:schema` directive at the top of
   their config or referencing it via [SchemaStore](https://www.schemastore.org/).
-- `tinty list --json` now includes Tinted8 `ui` and `syntax` color blocks for
   Tinted8 schemes, exposing every UI variable (39 dotted-path keys) and Syntax
   variable (105 dotted-path keys) alongside the existing palette, sourced
   from the canonical `tinted_builder::tinted8::{UiKey, SyntaxKey}` enums.
@@ -26,6 +25,9 @@
   internally.
 - `tinty list --json` now serializes `palette`, `ui`, and `syntax` maps with
   alphabetically-sorted keys for stable output across runs.
+- The `tinty gallery` detail sheet now lists every UI and Syntax variable for
+  Tinted8 schemes in two new panels alongside Palette. Base16 and Base24
+  schemes still show only Palette.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   Even Better TOML, Helix, Neovim, Zed) can use it for key autocomplete, hover
   docs, and inline validation by adding a `#:schema` directive at the top of
   their config or referencing it via [SchemaStore](https://www.schemastore.org/).
+- `tinty list --json` now includes Tinted8 `ui` and `syntax` color blocks for
   Tinted8 schemes, exposing every UI variable (39 dotted-path keys) and Syntax
   variable (105 dotted-path keys) alongside the existing palette, sourced
   from the canonical `tinted_builder::tinted8::{UiKey, SyntaxKey}` enums.
@@ -38,6 +39,12 @@
   `link.normal.{background,foreground}`, and split `cursor.{normal,muted}`
   into `.background` / `.foreground` sub-fields. Internal change for
   consumers; the gallery picks these up automatically.
+- The `tinty gallery` code preview for Tinted8 schemes now sources its
+  per-token colors (`bg`, `fg`, `muted`, `comment`, `keyword`, `function`,
+  `string`, `number`, `type`, `builtin`, `parameter`, `added`, `deleted`)
+  from the scheme's authored `syntax.*` and `ui.*` values rather than a
+  hand-picked palette mapping, so authored overrides drive the preview.
+  ANSI roles still come from the palette, and Base16/Base24 are unchanged.
 
 ### Removed
 

--- a/src/operations/gallery/gallery.css
+++ b/src/operations/gallery/gallery.css
@@ -621,21 +621,23 @@ h1 {
 }
 
 .swatch-color {
-  height: 42px;
+  display: flex;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
   box-shadow: inset 0 0 0 1px rgb(0 0 0 / 8%);
+}
+
+.swatch-hex {
+  font: 10.5px/1 var(--font-mono);
+  letter-spacing: .02em;
 }
 
 .swatch-label {
   padding: 6px 8px;
-  font: 11.5px/1.3 var(--font-mono);
-  color: var(--ink-1);
-}
-
-.swatch-label span {
-  display: block;
   overflow-wrap: anywhere;
-  color: var(--ink-3);
-  font-size: 10.5px;
+  color: var(--ink-1);
+  font: 11.5px/1.3 var(--font-mono);
 }
 
 .variable-list {

--- a/src/operations/gallery/gallery.css
+++ b/src/operations/gallery/gallery.css
@@ -305,7 +305,8 @@ h1 {
 
 .filter-group,
 .theme-switcher,
-.preview-toolbar {
+.preview-toolbar,
+.variables-toggle {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 2px;
@@ -336,8 +337,16 @@ h1 {
 
 .filter-group .chip,
 .theme-switcher .chip,
-.preview-toolbar .chip {
+.preview-toolbar .chip,
+.variables-toggle .chip {
   border-radius: var(--radius-full);
+}
+
+.variables-toggle {
+  display: flex;
+  justify-content: center;
+  width: fit-content;
+  margin: 0 auto 14px;
 }
 
 .preview-toolbar .chip {
@@ -541,21 +550,40 @@ h1 {
 }
 
 .metadata {
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 8px 14px;
-  margin: 0;
   font-size: 13px;
 }
 
-.metadata dt {
+.metadata-top {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 14px;
+  margin-bottom: 12px;
+}
+
+.metadata-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.metadata-col {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 10px;
+  align-content: start;
+}
+
+.metadata-row {
+  display: contents;
+}
+
+.metadata-label {
   color: var(--ink-3);
   font-weight: 500;
   letter-spacing: .01em;
 }
 
-.metadata dd {
-  margin: 0;
+.metadata-value {
   color: var(--ink-1);
   font-weight: 500;
   font-variant-numeric: tabular-nums;
@@ -570,6 +598,12 @@ h1 {
 
 .sheet-glass-panel .palette {
   grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+/* Tinted8 palettes are 33 entries (11 colors x 3 variants) — 3 columns
+   distribute evenly with one color per row. */
+.sheet-glass-panel .palette[data-size="33"] {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .swatch {
@@ -602,6 +636,47 @@ h1 {
   overflow-wrap: anywhere;
   color: var(--ink-3);
   font-size: 10.5px;
+}
+
+.variable-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.variable-row {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 5px 0;
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+}
+
+.variable-row:last-child {
+  border-bottom: none;
+}
+
+.variable-key {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-2);
+  font: 11px/1.3 var(--font-mono);
+}
+
+.variable-pill {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font: 10.5px/1.4 var(--font-mono);
+  letter-spacing: .02em;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 14%);
+}
+
+.palette[hidden],
+.variable-list[hidden],
+.section-label[hidden],
+.variables-toggle[hidden] {
+  display: none;
 }
 
 .empty {

--- a/src/operations/gallery/gallery.js
+++ b/src/operations/gallery/gallery.js
@@ -253,17 +253,20 @@ function renderColorMap(container, map) {
     .forEach(([name, value]) => {
       const swatch = document.createElement("div");
       const block = document.createElement("div");
-      const label = document.createElement("div");
       const hex = document.createElement("span");
+      const label = document.createElement("div");
 
       swatch.className = "swatch";
       block.className = "swatch-color";
+      hex.className = "swatch-hex";
       label.className = "swatch-label";
-      block.style.background = value.hex_str;
-      label.textContent = name;
-      hex.textContent = value.hex_str;
 
-      label.append(hex);
+      block.style.background = value.hex_str;
+      hex.textContent = value.hex_str;
+      hex.style.color = pillTextColor(value.rgb, value.hex_str);
+      label.textContent = name;
+
+      block.append(hex);
       swatch.append(block, label);
       container.append(swatch);
     });
@@ -277,8 +280,14 @@ function relativeLuminance(rgb) {
   return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
 }
 
-function pillTextColor(rgb) {
-  return relativeLuminance(rgb) > 0.45 ? "#0b0d10" : "#f8f9fb";
+// Hue-aware text color: starts from a near-black or near-white base depending
+// on the swatch luminance, then mixes ~25% of the swatch color in. Keeps the
+// text high-contrast (dark on light, light on dark) while picking up a tonal
+// hint of the swatch's hue. Uses color-mix in oklab for perceptual mixing.
+function pillTextColor(rgb, hexStr) {
+  const isLight = relativeLuminance(rgb) > 0.45;
+  const base = isLight ? "#06080a" : "#fafbfd";
+  return `color-mix(in oklab, ${hexStr} 25%, ${base} 75%)`;
 }
 
 function renderVariableList(container, map) {
@@ -298,7 +307,7 @@ function renderVariableList(container, map) {
       key.textContent = name;
       pill.textContent = value.hex_str;
       pill.style.background = value.hex_str;
-      pill.style.color = pillTextColor(value.rgb);
+      pill.style.color = pillTextColor(value.rgb, value.hex_str);
 
       row.append(key, pill);
       container.append(row);

--- a/src/operations/gallery/gallery.js
+++ b/src/operations/gallery/gallery.js
@@ -6,6 +6,7 @@ const state = {
   appearance: "all",
   pageTheme: "system",
   language: "rust",
+  variablesView: "palette",
 };
 let currentSheetId = null;
 let tooltipTimeoutId = null;
@@ -213,20 +214,41 @@ function loadSavedLanguage() {
   }
 }
 
-function metadataItem(label, value) {
-  const fragment = document.createDocumentFragment();
-  const dt = document.createElement("dt");
-  const dd = document.createElement("dd");
-  dt.textContent = label;
-  dd.textContent = value || "n/a";
-  fragment.append(dt, dd);
-  return fragment;
+function metadataRow(label, value) {
+  const row = document.createElement("div");
+  const labelEl = document.createElement("span");
+  const valueEl = document.createElement("span");
+  row.className = "metadata-row";
+  labelEl.className = "metadata-label";
+  valueEl.className = "metadata-value";
+  labelEl.textContent = label;
+  valueEl.textContent = value || "n/a";
+  row.append(labelEl, valueEl);
+  return row;
 }
 
-function renderPalette(container, scheme) {
-  container.textContent = "";
+function metadataGroup(className, ...rows) {
+  const group = document.createElement("div");
+  group.className = className;
+  group.append(...rows);
+  return group;
+}
 
-  Object.entries(scheme.palette)
+function setVariablesView(view) {
+  state.variablesView = view;
+  document.querySelectorAll("[data-variables-view]").forEach((button) => {
+    button.classList.toggle("active", button.dataset.variablesView === view);
+  });
+  document.getElementById("sheet-palette").hidden = view !== "palette";
+  document.getElementById("sheet-ui").hidden = view !== "ui";
+  document.getElementById("sheet-syntax").hidden = view !== "syntax";
+}
+
+function renderColorMap(container, map) {
+  container.textContent = "";
+  container.dataset.size = String(Object.keys(map).length);
+
+  Object.entries(map)
     .sort(([a], [b]) => a.localeCompare(b))
     .forEach(([name, value]) => {
       const swatch = document.createElement("div");
@@ -244,6 +266,42 @@ function renderPalette(container, scheme) {
       label.append(hex);
       swatch.append(block, label);
       container.append(swatch);
+    });
+}
+
+function relativeLuminance(rgb) {
+  const channels = rgb.map((c) => {
+    const norm = c / 255;
+    return norm <= 0.03928 ? norm / 12.92 : Math.pow((norm + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function pillTextColor(rgb) {
+  return relativeLuminance(rgb) > 0.45 ? "#0b0d10" : "#f8f9fb";
+}
+
+function renderVariableList(container, map) {
+  container.textContent = "";
+
+  Object.entries(map)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .forEach(([name, value]) => {
+      const row = document.createElement("div");
+      const key = document.createElement("span");
+      const pill = document.createElement("span");
+
+      row.className = "variable-row";
+      key.className = "variable-key";
+      pill.className = "variable-pill";
+
+      key.textContent = name;
+      pill.textContent = value.hex_str;
+      pill.style.background = value.hex_str;
+      pill.style.color = pillTextColor(value.rgb);
+
+      row.append(key, pill);
+      container.append(row);
     });
 }
 
@@ -336,15 +394,41 @@ function applySheetState(scheme, updateHash) {
   const metadata = document.getElementById("sheet-metadata");
   metadata.textContent = "";
   metadata.append(
-    metadataItem("ID", scheme.id),
-    metadataItem("Author", scheme.author),
-    metadataItem("System", scheme.system),
-    metadataItem("Variant", scheme.variant),
-    metadataItem("Appearance", appearance(scheme)),
-    metadataItem("Background L*", scheme.lightness?.background?.toFixed(2)),
-    metadataItem("Foreground L*", scheme.lightness?.foreground?.toFixed(2)),
+    metadataGroup(
+      "metadata-top",
+      metadataRow("ID", scheme.id),
+      metadataRow("Author", scheme.author),
+    ),
+    metadataGroup(
+      "metadata-cols",
+      metadataGroup(
+        "metadata-col",
+        metadataRow("System", scheme.system),
+        metadataRow("Variant", scheme.variant),
+        metadataRow("Appearance", appearance(scheme)),
+      ),
+      metadataGroup(
+        "metadata-col",
+        metadataRow("Bg L*", scheme.lightness?.background?.toFixed(2)),
+        metadataRow("Fg L*", scheme.lightness?.foreground?.toFixed(2)),
+      ),
+    ),
   );
-  renderPalette(document.getElementById("sheet-palette"), scheme);
+  renderColorMap(document.getElementById("sheet-palette"), scheme.palette);
+
+  const hasVariables = Boolean(scheme.ui && scheme.syntax);
+  const label = document.getElementById("variables-label");
+  const toggle = document.getElementById("variables-toggle");
+  label.hidden = hasVariables;
+  toggle.hidden = !hasVariables;
+
+  if (hasVariables) {
+    renderVariableList(document.getElementById("sheet-ui"), scheme.ui);
+    renderVariableList(document.getElementById("sheet-syntax"), scheme.syntax);
+    setVariablesView(state.variablesView);
+  } else {
+    setVariablesView("palette");
+  }
 
   if (updateHash) {
     setSheetHash(scheme.id);
@@ -555,6 +639,12 @@ document.getElementById("language-select").addEventListener("change", (event) =>
 document.querySelectorAll("[data-preview-language]").forEach((button) => {
   button.addEventListener("click", () => {
     setLanguage(button.dataset.previewLanguage);
+  });
+});
+
+document.querySelectorAll("[data-variables-view]").forEach((button) => {
+  button.addEventListener("click", () => {
+    setVariablesView(button.dataset.variablesView);
   });
 });
 

--- a/src/operations/gallery/gallery.js
+++ b/src/operations/gallery/gallery.js
@@ -40,9 +40,26 @@ function hasSnippet(lang) {
 
 const FALLBACK_LANGUAGE = "rust";
 
-function color(scheme, key) {
-  return scheme.palette[key]?.hex_str || fallbackPalette[key] || fallbackPalette.base05;
-}
+// For Tinted8 schemes, map each non-ANSI preview role to a canonical
+// dotted-path key in `scheme.syntax` or `scheme.ui`. Lets authored scheme
+// overrides drive the gallery preview instead of the hand-rolled palette
+// guess. ANSI roles aren't in the syntax/ui spec — they fall through to
+// the palette mapping.
+const TINTED8_ROLE_PATHS = {
+  bg: ["ui", "global.background.normal"],
+  fg: ["ui", "global.foreground.normal"],
+  muted: ["ui", "global.foreground.dark"],
+  comment: ["syntax", "comment"],
+  keyword: ["syntax", "keyword"],
+  function: ["syntax", "entity.name.function"],
+  string: ["syntax", "string"],
+  number: ["syntax", "constant.numeric"],
+  type: ["syntax", "entity.name.type"],
+  builtin: ["syntax", "support.function.builtin"],
+  parameter: ["syntax", "variable.parameter"],
+  added: ["syntax", "markup.inserted"],
+  deleted: ["syntax", "markup.deleted"],
+};
 
 const PREVIEW_ROLE_KEYS = {
   base16: {
@@ -137,7 +154,7 @@ const PREVIEW_ROLES = [
   "ansi-bright-blue", "ansi-bright-magenta", "ansi-bright-cyan", "ansi-bright-white",
 ];
 
-function previewKey(scheme, role) {
+function palettePreviewKey(scheme, role) {
   const system = String(scheme.system).toLowerCase();
   if (system === "tinted8") {
     const variant = String(scheme.variant || "").toLowerCase() === "light" ? "light" : "dark";
@@ -148,6 +165,21 @@ function previewKey(scheme, role) {
     return PREVIEW_ROLE_KEYS.base24[role] ?? PREVIEW_ROLE_KEYS.base16[role];
   }
   return PREVIEW_ROLE_KEYS.base16[role];
+}
+
+function previewColor(scheme, role) {
+  if (String(scheme.system).toLowerCase() === "tinted8") {
+    const path = TINTED8_ROLE_PATHS[role];
+    if (path) {
+      const [source, key] = path;
+      const entry = scheme[source]?.[key];
+      if (entry?.hex_str) {
+        return entry.hex_str;
+      }
+    }
+  }
+  const key = palettePreviewKey(scheme, role);
+  return scheme.palette[key]?.hex_str || fallbackPalette[key] || fallbackPalette.base05;
 }
 
 function appearance(scheme) {
@@ -180,7 +212,7 @@ function matchesFilters(scheme) {
 
 function setPreviewColors(card, scheme) {
   PREVIEW_ROLES.forEach((role) => {
-    card.style.setProperty(`--preview-${role}`, color(scheme, previewKey(scheme, role)));
+    card.style.setProperty(`--preview-${role}`, previewColor(scheme, role));
   });
 }
 

--- a/src/operations/gallery/index.html
+++ b/src/operations/gallery/index.html
@@ -133,14 +133,21 @@
             <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16"></path><path d="M4 12h16"></path><path d="M4 17h16"></path><path d="M8 7v10"></path></svg>
             Properties
           </div>
-          <dl id="sheet-metadata" class="metadata"></dl>
+          <div id="sheet-metadata" class="metadata"></div>
         </section>
-        <section aria-label="Palette">
-          <div class="section-label">
+        <section aria-label="Colors">
+          <div id="variables-label" class="section-label">
             <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="13.5" cy="6.5" r="2.5"></circle><circle cx="17.5" cy="13.5" r="2.5"></circle><circle cx="8.5" cy="14.5" r="2.5"></circle><path d="M11.3 8.3 9.7 12.3"></path><path d="m15.5 8.7 1.1 2.4"></path></svg>
             Palette
           </div>
+          <div id="variables-toggle" class="variables-toggle" role="tablist" hidden>
+            <button type="button" class="chip active" role="tab" data-variables-view="palette">Palette</button>
+            <button type="button" class="chip" role="tab" data-variables-view="ui">UI</button>
+            <button type="button" class="chip" role="tab" data-variables-view="syntax">Syntax</button>
+          </div>
           <div id="sheet-palette" class="palette"></div>
+          <div id="sheet-ui" class="variable-list" hidden></div>
+          <div id="sheet-syntax" class="variable-list" hidden></div>
         </section>
       </div>
       <div class="sheet-main-footer">


### PR DESCRIPTION
**Stacked on #155.** Base will retarget to `main` automatically when #155 merges.

## Summary

Two changes to the gallery for Tinted8 schemes:

1. **New detail-sheet variable panels** — UI (~36 keys) and Syntax (~105 keys) are now browseable per-scheme in the right-side glass panel via a chip toggle.
2. **Preview-color accuracy** — the gallery's code preview now resolves Tinted8 syntax/ui colors from `scheme.syntax.*` and `scheme.ui.*` instead of a hand-rolled palette guess, so authored overrides drive the preview.

**This version is live here: https://tinted-gallery.bez.dev/** 👈

Base16 / Base24 schemes are unchanged in both respects.

## Detail-sheet panels

The detail sheet's right-side glass panel adapts to the scheme system:

- **Tinted8 schemes** get a `[Palette] [UI] [Syntax]` chip toggle in place of the static "Palette" header. Clicking a chip swaps the visible content in the same slot below; the others stay rendered but hidden (cheap re-toggle, no re-render). Selection persists across opening different schemes.
- **Base16 / Base24 schemes** are unchanged — same "Palette" header + swatch grid.

| View | Layout | Content |
|---|---|---|
| Palette (Tinted8) | swatch grid, **3 cols × 11 rows** | 33 entries, evenly distributed (11 colors × 3 variants) |
| Palette (Base16) | swatch grid, 4 cols × 4 rows | 16 entries, unchanged |
| Palette (Base24) | swatch grid, 4 cols × 6 rows | 24 entries, unchanged |
| UI | "key — pill" list | ~36 dotted-path keys, alphabetical |
| Syntax | "key — pill" list | ~105 dotted-path keys, alphabetical |

Palette swatches now center the hex value inside the colored block (with the variable name as a small label below). UI/Syntax rows show the variable name on the left and a single rounded pill on the right where **the pill background is the actual color** and **the hex value is the pill text**.

Pill / swatch text color picks up a 25% tonal cast of the swatch color, mixed into a near-black (`#06080a`) or near-white (`#fafbfd`) base depending on swatch luminance via `color-mix(in oklab, ...)`. Keeps WCAG-direction contrast (dark on light, light on dark) while picking up the swatch's hue.

## Preview-color accuracy (Tinted8 only)

`previewColor(scheme, role)` replaces the prior `previewKey` + `color` chain. For Tinted8, non-ANSI preview roles now resolve via canonical dotted-path keys in `scheme.syntax.*` and `scheme.ui.*`:

| preview role | tinted8 source |
|---|---|
| `bg` | `ui.global.background.normal` |
| `fg` | `ui.global.foreground.normal` |
| `muted` | `ui.global.foreground.dark` |
| `comment` | `syntax.comment` |
| `keyword` | `syntax.keyword` |
| `function` | `syntax.entity.name.function` |
| `string` | `syntax.string` |
| `number` | `syntax.constant.numeric` |
| `type` | `syntax.entity.name.type` |
| `builtin` | `syntax.support.function.builtin` |
| `parameter` | `syntax.variable.parameter` |
| `added` | `syntax.markup.inserted` |
| `deleted` | `syntax.markup.deleted` |

ANSI roles (`ansi-red`, `ansi-bright-blue`, etc.) stay on the palette — they aren't in the syntax/ui spec. Base16/Base24 routing is unchanged. If a syntax/ui key is missing, the function falls back to the palette mapping so nothing renders blank.

This closes the original PR review feedback that motivated #155: schemes that author overrides like Catppuccin Mocha's `keyword.operator: #94e2d5` or `meta.function: #89b4fa` now drive the preview.

## Other tweaks

- Properties section is restacked: ID + Author full-width on top, then a two-column grid (System / Variant / Appearance | Bg L* / Fg L*). Tightens vertical space.
- Tinted8 palette grid sized to 3 columns via `data-size` attribute on the container — set by the renderer based on entry count, picked up by a CSS rule.
- Toggle row reuses the existing chip-toolbar visual style (matches `.preview-toolbar`, `.filter-group`, `.theme-switcher`).

## Out of scope (deliberately)

- **Surfacing `syntax.*` / `ui.*` as `TINTY_SCHEME_*` env vars in `apply`** — would 5× the env surface per Tinted8 apply with no concrete consumer asking. Parked until a hook author has a use case.

## Dependencies

Depends on the `SchemeEntry` shape change from #155. `scheme.ui` and `scheme.syntax` are the source of truth and are only present for Tinted8 entries; the toggle and preview-resolution stay graceful when those fields are absent.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --test cli_list_subcommand_tests --test cli_gallery_subcommand_tests` passes (no new tests in this PR — gallery surface is best verified visually)
- [x] Manual: opened a Tinted8 scheme, confirmed all three views render correctly and toggle works
- [x] Manual: opened a Base16 scheme, confirmed no toggle appears and Palette header is shown instead
- [x] Manual: confirmed Catppuccin Mocha's authored syntax overrides flow into the code preview
- [ ] Reviewer to spot-check pill/swatch contrast on a few light/dark schemes (e.g. catppuccin-latte vs. catppuccin-mocha)