### PR TITLE
deps(gix): add gix backend stub behind TINTY_USE_GIX (gix migration: Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,7 @@ dependencies = [
  "gix-date",
  "gix-error",
  "gix-hash",
+ "gix-hashtable",
  "gix-object",
  "gix-revwalk",
  "gix-trace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +146,12 @@ checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -182,6 +203,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,15 +238,9 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitstream-io"
@@ -206,6 +249,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
  "no_std_io2",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -233,10 +296,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -255,6 +330,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -306,6 +387,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color-thief"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +424,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const_format"
@@ -348,12 +457,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -388,6 +531,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,10 +597,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equator"
@@ -483,13 +675,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
-name = "fastrand"
-version = "1.9.0"
+name = "faster-hex"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
 dependencies = [
- "instant",
+ "heapless",
+ "serde",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -521,6 +720,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +745,18 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -556,14 +778,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -573,9 +862,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -586,6 +877,939 @@ checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
+]
+
+[[package]]
+name = "gix"
+version = "0.83.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ca11598b70811d7b16ff90945a6e57dfe521e85b744e51636965fe39cc8f60"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror 2.0.18",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e041a626c64cb69e4117fcdf80da8d0e454fba3b1f420412792d191f52251aee"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
+dependencies = [
+ "bstr",
+ "gix-credentials",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revwalk",
+ "gix-shallow",
+ "gix-trace",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
+dependencies = [
+ "bitflags",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
+dependencies = [
+ "base64",
+ "bstr",
+ "gix-command",
+ "gix-credentials",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -600,22 +1824,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex_color"
@@ -642,6 +1890,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
 dependencies = [
  "utf8-width",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -793,16 +2139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -817,14 +2154,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
+name = "io-close"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
 dependencies = [
- "hermit-abi",
  "libc",
- "windows-sys 0.48.0",
+ "winapi",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -849,6 +2201,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +2298,18 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -872,6 +2326,15 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "lebe"
@@ -901,21 +2364,31 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -930,6 +2403,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -949,6 +2439,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +2467,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1007,6 +2523,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "noop_proc_macro"
@@ -1077,6 +2599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +2632,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1167,12 +2718,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1186,6 +2743,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
 dependencies = [
  "nom 7.1.3",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1213,6 +2785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -1263,6 +2844,62 @@ checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1411,11 +3048,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1459,6 +3105,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,17 +3167,120 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.28"
+name = "ring"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
- "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1513,6 +3302,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1588,6 +3415,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +3454,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,10 +3473,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1627,10 +3497,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -1648,6 +3534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +3548,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1671,16 +3572,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "autocfg",
- "cfg-if",
  "fastrand",
- "redox_syscall",
+ "getrandom 0.3.4",
+ "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1796,6 +3696,7 @@ dependencies = [
  "clap_complete",
  "dirs",
  "fs2",
+ "gix",
  "hex_color",
  "home",
  "rand 0.8.6",
@@ -1841,6 +3742,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +3820,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +3936,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1950,6 +3985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "vte"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +4010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,9 +4035,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1997,10 +4047,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.118"
+name = "wasm-bindgen-futures"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2008,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2021,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -2041,6 +4101,35 @@ dependencies = [
  "regex",
  "thiserror 2.0.18",
  "walkdir",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2097,9 +4186,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
@@ -2115,13 +4204,14 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -2130,45 +4220,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2268,6 +4364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +4401,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ gix = { version = "0.83", default-features = false, features = [
     "blocking-http-transport-reqwest-rust-tls",
     "worktree-mutation",
     "status",
+    "revision",
     "sha1",
     "max-performance-safe",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,16 @@ home = "0.5.12"
 rand = "0.8.6"
 regex = "1.12"
 rayon = "1.11"
-tempfile = "=3.6.0"
+tempfile = "3"
 fs2 = "0.4.3"
 dirs = "6.0.0"
+gix = { version = "0.83", default-features = false, features = [
+    "blocking-http-transport-reqwest-rust-tls",
+    "worktree-mutation",
+    "status",
+    "sha1",
+    "max-performance-safe",
+] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,9 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "ISC",          # rustls-webpki, aws-lc-rs
     "MIT",
+    "MIT-0",        # aws-lc-sys
     "MPL-2.0",
     "Unicode-3.0",
     "GPL-3.0-only",
@@ -35,19 +37,25 @@ exceptions = [
 multiple-versions = "deny"
 wildcards = "deny"
 deny = [
+    # Principled bans — keep C TLS / SSH crypto out of the dep tree.
     { name = "openssl" },
     { name = "openssl-sys" },
     { name = "libssh2-sys" },
 
-    # No reason to use these
-    { name = "cmake" },
+    # Keep the binary lean.
     { name = "windows" },
+
+    # `cmake` was banned here previously. `gix 0.83`'s HTTPS feature pulls
+    # `aws-lc-rs` (→ `aws-lc-sys` → `cmake` build-dep); until gitoxide ships a
+    # `-rust-tls-ring` variant, we accept the cmake build-time dependency.
 ]
 skip = [
-    { name = "bitflags" }, # Related to `tempfile` version lock
     { name = "thiserror" },
     { name = "thiserror-impl" },
     { name = "nom" },
+    # Introduced by the gix 0.83 dep tree.
+    { name = "getrandom" },
+    { name = "hashbrown" },
 ]
 
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::path::Path;
 
 pub mod git_shell;
+pub mod gix;
 
 /// High-level repository operations tinty performs against a `[[items]]` entry:
 /// fetching it onto disk for the first time (`install`), bringing it up to a
@@ -18,13 +19,27 @@ pub trait RepositoryBackend {
     fn is_clean(&self, target: &Path) -> Result<bool>;
 }
 
+/// Environment variable for opting in to the gix backend at runtime.
+///
+/// Truthy values: `1`, `true`, `TRUE`, `yes`. Anything else (including unset)
+/// keeps the default git-shell-out backend.
+const USE_GIX_ENV: &str = "TINTY_USE_GIX";
+
+fn use_gix() -> bool {
+    std::env::var(USE_GIX_ENV).is_ok_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+}
+
 /// Returns the active repository backend for this invocation.
 ///
-/// Phase 1 always returns the git-shell-out backend. Phase 2 introduces the
-/// gix backend and runtime dispatch via `TINTY_USE_GIX`.
+/// Defaults to the git-shell-out backend. Set `TINTY_USE_GIX=1` to opt in to
+/// the gix backend (currently a stub — Phase 2 of the migration).
 #[must_use]
 pub fn backend() -> Box<dyn RepositoryBackend> {
-    Box::new(git_shell::GitShellBackend)
+    if use_gix() {
+        Box::new(gix::GixBackend)
+    } else {
+        Box::new(git_shell::GitShellBackend)
+    }
 }
 
 pub fn install(url: &str, target: &Path, revision: Option<&str>) -> Result<()> {

--- a/src/repo/gix.rs
+++ b/src/repo/gix.rs
@@ -1,17 +1,40 @@
 #![allow(clippy::module_name_repetitions)]
 
 use crate::repo::RepositoryBackend;
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 
 /// Repository backend implemented with the pure-Rust `gix` (gitoxide) library.
 pub struct GixBackend;
 
 impl RepositoryBackend for GixBackend {
-    fn install(&self, _url: &str, _target: &Path, _revision: Option<&str>) -> Result<()> {
-        bail!(
-            "gix backend: install is not yet implemented (set TINTY_USE_GIX=0 to use the git CLI)"
-        )
+    fn install(&self, url: &str, target: &Path, revision: Option<&str>) -> Result<()> {
+        if target.exists() {
+            return Err(anyhow!(
+                "Error cloning {}. Target directory '{}' already exists",
+                url,
+                target.display()
+            ));
+        }
+
+        if revision.is_some() {
+            bail!(
+                "gix backend: install with a pinned revision is not yet implemented \
+                 (set TINTY_USE_GIX=0 to use the git CLI)"
+            );
+        }
+
+        let interrupt = AtomicBool::new(false);
+        let mut prepare = gix::prepare_clone(url, target)
+            .with_context(|| format!("Failed to set up clone of {url}"))?;
+        let (mut checkout, _outcome) = prepare
+            .fetch_then_checkout(gix::progress::Discard, &interrupt)
+            .with_context(|| format!("Failed to clone repository from {url}"))?;
+        checkout
+            .main_worktree(gix::progress::Discard, &interrupt)
+            .with_context(|| format!("Failed to check out worktree at {}", target.display()))?;
+        Ok(())
     }
 
     fn update(&self, _target: &Path, _url: &str, _revision: Option<&str>) -> Result<()> {

--- a/src/repo/gix.rs
+++ b/src/repo/gix.rs
@@ -41,15 +41,27 @@ impl RepositoryBackend for GixBackend {
         bail!("gix backend: update is not yet implemented (set TINTY_USE_GIX=0 to use the git CLI)")
     }
 
+    /// Reports whether the working directory is clean.
+    ///
+    /// Intentional divergence from the CLI backend: untracked files do **not**
+    /// count as dirty here. The CLI backend uses `git status --porcelain` which
+    /// reports untracked entries; this implementation excludes them so that
+    /// artifacts written by `tinty generate-scheme` (and similar) into a cloned
+    /// template repo don't block `tinty update` / `tinty sync`. See
+    /// tinted-theming/tinty#130.
+    ///
+    /// Modified, deleted, renamed, or conflicted entries on tracked files all
+    /// still count as dirty, matching the CLI backend.
     fn is_clean(&self, target: &Path) -> Result<bool> {
         let repo = gix::open(target)
             .with_context(|| format!("Failed to open git repository at {}", target.display()))?;
-        // `is_dirty` reports any change to tracked files plus any untracked
-        // (non-ignored) files — equivalent to `git status --porcelain` being
-        // non-empty, which is the contract the CLI backend implements.
-        let dirty = repo
-            .is_dirty()
-            .with_context(|| format!("Failed to read status in {}", target.display()))?;
-        Ok(!dirty)
+        let mut iter = repo
+            .status(gix::progress::Discard)
+            .with_context(|| format!("Failed to read status in {}", target.display()))?
+            .untracked_files(gix::status::UntrackedFiles::None)
+            .into_iter(None)
+            .with_context(|| format!("Failed to iterate status in {}", target.display()))?;
+        let any_change = iter.next().is_some();
+        Ok(!any_change)
     }
 }

--- a/src/repo/gix.rs
+++ b/src/repo/gix.rs
@@ -2,8 +2,10 @@
 
 use crate::repo::RepositoryBackend;
 use anyhow::{anyhow, bail, Context, Result};
+use gix::bstr::ByteSlice;
 use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
 use gix::refs::Target;
+use gix::remote::Direction;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
@@ -25,11 +27,9 @@ impl RepositoryBackend for GixBackend {
             .with_context(|| format!("Failed to set up clone of {url}"))?;
 
         // For tag- or branch-named revisions, point gix at the requested ref
-        // up front so the clone fetches and checks it out in one step. This
-        // also gets HEAD attached when the ref is a branch, matching what
-        // `git clone --branch` does. SHA revisions don't go through this
-        // path because they aren't a ref name; they fall through to the
-        // post-fetch resolve-and-checkout below.
+        // up front so the clone fetches and checks it out in one step. SHA
+        // revisions don't go through this path because they aren't a ref
+        // name; they fall through to the post-fetch resolve-and-checkout.
         if let Some(rev) = revision {
             if !looks_like_sha(rev) {
                 prepare = prepare
@@ -42,11 +42,6 @@ impl RepositoryBackend for GixBackend {
         let (mut checkout, _outcome) = match fetch_result {
             Ok(t) => t,
             Err(e) => {
-                // For non-SHA revisions, gix surfaces an error like
-                // "The remote didn't have any ref that matched '<rev>'"
-                // when neither a tag nor a branch matches. Normalize to the
-                // CLI backend's wording so callers (and tests) see the same
-                // message regardless of which backend ran.
                 if let Some(rev) = revision {
                     if !looks_like_sha(rev) && format!("{e:#}").contains("didn't have any ref") {
                         bail!("cannot resolve {rev} into a Git SHA1");
@@ -61,8 +56,15 @@ impl RepositoryBackend for GixBackend {
 
         if let Some(rev) = revision {
             let post = if looks_like_sha(rev) {
-                checkout_sha(&repo, rev)
+                // SHA path: clone landed on the default branch; resolve and
+                // detach onto the requested SHA.
+                resolve_revision(&repo, "origin", rev)
+                    .and_then(|resolved| checkout_revision(&repo, &resolved, rev))
             } else {
+                // Tag/branch path: gix already checked out the ref. For
+                // annotated tags we still need to detach HEAD onto the
+                // peeled commit so `git rev-parse HEAD` returns the commit
+                // SHA rather than the tag-object SHA.
                 detach_if_tag(&repo)
             };
             if let Err(e) = post {
@@ -76,14 +78,18 @@ impl RepositoryBackend for GixBackend {
 
     /// Update an installed repository to a (possibly new) URL and revision.
     ///
-    /// Implementation note: rather than mutating the existing repository in
-    /// place (which the CLI backend does via a temp-remote dance to keep
-    /// `.git/config` consistent), we move the existing repo aside, run a
-    /// fresh `install` into the target path, and only delete the moved-aside
-    /// copy on success. On failure we restore the moved-aside copy. This
-    /// gives atomic semantics via filesystem rename without ever touching
-    /// the .git/config file mid-operation, and lets us share all the
-    /// resolve / checkout logic with `install`.
+    /// Validate-first design:
+    ///
+    /// 1. ls-refs against the new URL via an in-memory anonymous remote.
+    ///    This bails before any local mutation if the requested tag/branch
+    ///    doesn't exist on the remote (and the revision isn't a SHA we can
+    ///    verify post-fetch).
+    /// 2. If the URL changed, write the new URL to `.git/config`. The
+    ///    original URL is kept in memory for rollback.
+    /// 3. Fetch from origin, resolve the revision against local refs, and
+    ///    update HEAD + worktree.
+    /// 4. On any failure during step 3, restore the original URL in
+    ///    `.git/config` and propagate the error.
     fn update(&self, target: &Path, url: &str, revision: Option<&str>) -> Result<()> {
         if !target.is_dir() {
             return Err(anyhow!(
@@ -92,39 +98,48 @@ impl RepositoryBackend for GixBackend {
             ));
         }
 
-        let backup = backup_path_for(target);
-        if backup.exists() {
-            std::fs::remove_dir_all(&backup).with_context(|| {
-                format!("Failed to remove stale backup at {}", backup.display())
+        let mut repo = gix::open(target)
+            .with_context(|| format!("Failed to open git repository at {}", target.display()))?;
+        let rev_str = revision.unwrap_or("main");
+
+        // Phase 1: ls-refs against the new URL — no local mutation yet.
+        let _kind_hint = probe_revision_kind_at(&repo, url, rev_str)?;
+
+        // Phase 2: capture the current origin URL and switch to the new one
+        // if it changed. The captured URL is used for rollback if the work
+        // below fails.
+        let old_url = read_origin_url(&repo)?;
+        let url_changed = old_url.as_bstr() != url.as_bytes().as_bstr();
+        if url_changed {
+            write_origin_url(&repo, url)?;
+            repo = gix::open(target).with_context(|| {
+                format!(
+                    "Failed to re-open repository after URL update at {}",
+                    target.display()
+                )
             })?;
         }
-        std::fs::rename(target, &backup).with_context(|| {
-            format!(
-                "Failed to move {} aside to {}",
-                target.display(),
-                backup.display()
-            )
-        })?;
 
-        match self.install(url, target, revision) {
-            Ok(()) => {
-                std::fs::remove_dir_all(&backup)
-                    .with_context(|| format!("Failed to remove backup at {}", backup.display()))?;
-                Ok(())
-            }
+        // Phase 3: fetch + resolve + checkout. Encapsulated so we can run
+        // rollback on any failure.
+        let do_work = || -> Result<()> {
+            fetch_origin(&repo)?;
+            let resolved = resolve_revision(&repo, "origin", rev_str)?;
+            checkout_revision(&repo, &resolved, rev_str)?;
+            Ok(())
+        };
+
+        match do_work() {
+            Ok(()) => Ok(()),
             Err(e) => {
-                // Clean up any partial install at the target path, then
-                // restore the original repo from backup.
-                if target.exists() {
-                    let _ = std::fs::remove_dir_all(target);
+                if url_changed {
+                    let restored = std::str::from_utf8(old_url.as_ref())
+                        .map(str::to_owned)
+                        .ok();
+                    if let Some(orig) = restored {
+                        let _ = write_origin_url(&repo, &orig);
+                    }
                 }
-                std::fs::rename(&backup, target).with_context(|| {
-                    format!(
-                        "Failed to restore backup from {} to {} (original error: {e:#})",
-                        backup.display(),
-                        target.display()
-                    )
-                })?;
                 Err(e)
             }
         }
@@ -153,6 +168,263 @@ impl RepositoryBackend for GixBackend {
         let any_change = iter.next().is_some();
         Ok(!any_change)
     }
+}
+
+#[derive(Clone, Copy)]
+enum RevisionKind {
+    Tag,
+    Branch,
+    Sha,
+}
+
+struct ResolvedRevision {
+    /// The commit SHA that the revision resolves to. For annotated tags
+    /// this is the *peeled* commit, not the tag object.
+    commit: gix::ObjectId,
+    kind: RevisionKind,
+}
+
+/// Probe a remote URL for whether it has the requested revision, without
+/// touching any local state. Uses an anonymous in-memory remote and
+/// `ref_map` (which performs an ls-refs handshake but doesn't fetch
+/// objects). Returns the classified `RevisionKind` so callers can decide
+/// whether to follow up with a fetch or jump straight to SHA verification.
+fn probe_revision_kind_at(repo: &gix::Repository, url: &str, rev: &str) -> Result<RevisionKind> {
+    // Anonymous remotes start with no refspecs; ref_map filters through
+    // them, so without these the response is empty even if the remote has
+    // matching refs. Configure the standard fetch refspecs explicitly.
+    let probe = repo
+        .remote_at(url)
+        .with_context(|| format!("Failed to build in-memory remote at {url}"))?
+        .with_refspecs(
+            [
+                "+refs/heads/*:refs/remotes/probe/*",
+                "+refs/tags/*:refs/tags/*",
+            ],
+            Direction::Fetch,
+        )
+        .with_context(|| "Failed to set refspecs on probe remote")?;
+    let connection = probe
+        .connect(Direction::Fetch)
+        .with_context(|| format!("Failed to connect to {url}"))?;
+    let (ref_map, _handshake) = connection
+        .ref_map(
+            gix::progress::Discard,
+            gix::remote::ref_map::Options::default(),
+        )
+        .with_context(|| format!("Failed to enumerate refs at {url}"))?;
+
+    let tag_name = format!("refs/tags/{rev}");
+    let head_name = format!("refs/heads/{rev}");
+    let mut found_tag = false;
+    let mut found_branch = false;
+    for r in &ref_map.remote_refs {
+        let (name, _target, _peeled) = r.unpack();
+        if name.as_bstr() == tag_name.as_bytes() {
+            found_tag = true;
+        } else if name.as_bstr() == head_name.as_bytes() {
+            found_branch = true;
+        }
+    }
+
+    if found_tag {
+        return Ok(RevisionKind::Tag);
+    }
+    if found_branch {
+        return Ok(RevisionKind::Branch);
+    }
+    if !looks_like_sha(rev) {
+        bail!("cannot resolve {rev} into a Git SHA1");
+    }
+    Ok(RevisionKind::Sha)
+}
+
+/// Read the fetch URL configured for `origin` in this repository.
+fn read_origin_url(repo: &gix::Repository) -> Result<gix::bstr::BString> {
+    let remote = repo
+        .find_remote("origin")
+        .with_context(|| "Failed to find origin remote")?;
+    let url = remote
+        .url(Direction::Fetch)
+        .ok_or_else(|| anyhow!("origin has no fetch URL configured"))?;
+    Ok(url.to_bstring())
+}
+
+/// Persist a new fetch URL for `origin` to `.git/config`. The caller is
+/// expected to re-open the repository afterwards to pick up the change.
+fn write_origin_url(repo: &gix::Repository, url: &str) -> Result<()> {
+    let config_path = repo.git_dir().join("config");
+    let mut config =
+        gix::config::File::from_path_no_includes(config_path.clone(), gix::config::Source::Local)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+    config
+        .set_raw_value("remote.origin.url", url.as_bytes())
+        .with_context(|| format!("Failed to set remote.origin.url = {url}"))?;
+    let mut file = std::fs::File::create(&config_path)
+        .with_context(|| format!("Failed to open {} for writing", config_path.display()))?;
+    config
+        .write_to(&mut file)
+        .with_context(|| format!("Failed to write to {}", config_path.display()))?;
+    Ok(())
+}
+
+/// Fetch from the configured `origin` remote, updating `refs/remotes/origin/*`
+/// and `refs/tags/*` per the existing refspecs in `.git/config`.
+fn fetch_origin(repo: &gix::Repository) -> Result<()> {
+    let interrupt = AtomicBool::new(false);
+    let remote = repo
+        .find_remote("origin")
+        .with_context(|| "Failed to find origin remote")?;
+    let connection = remote
+        .connect(Direction::Fetch)
+        .with_context(|| "Failed to connect to origin")?;
+    let prepare = connection
+        .prepare_fetch(
+            gix::progress::Discard,
+            gix::remote::ref_map::Options::default(),
+        )
+        .with_context(|| "Failed to prepare fetch from origin")?;
+    prepare
+        .receive(gix::progress::Discard, &interrupt)
+        .with_context(|| "Failed to receive objects from origin")?;
+    Ok(())
+}
+
+/// Resolve a revision string against an existing repository's local refs,
+/// using the same precedence as the CLI backend: tag → branch → SHA. The
+/// `remote_name` controls which `refs/remotes/<name>/*` namespace counts
+/// for branch and SHA-reachability lookups.
+fn resolve_revision(
+    repo: &gix::Repository,
+    remote_name: &str,
+    rev: &str,
+) -> Result<ResolvedRevision> {
+    // Tag (peel through annotated tag objects to a commit).
+    let tag_ref_name = format!("refs/tags/{rev}");
+    if let Ok(mut reference) = repo.find_reference(tag_ref_name.as_str()) {
+        let commit = reference
+            .peel_to_id()
+            .with_context(|| format!("Failed to peel {tag_ref_name}"))?
+            .detach();
+        return Ok(ResolvedRevision {
+            commit,
+            kind: RevisionKind::Tag,
+        });
+    }
+
+    // Branch (remote-tracking ref).
+    let branch_ref_name = format!("refs/remotes/{remote_name}/{rev}");
+    if let Ok(mut reference) = repo.find_reference(branch_ref_name.as_str()) {
+        let commit = reference
+            .peel_to_id()
+            .with_context(|| format!("Failed to peel {branch_ref_name}"))?
+            .detach();
+        return Ok(ResolvedRevision {
+            commit,
+            kind: RevisionKind::Branch,
+        });
+    }
+
+    // SHA. Validate shape, then verify reachability from a remote-tracking
+    // branch (matches the CLI backend's `git branch -a --contains <sha>`
+    // semantic, filtered to the relevant remote prefix).
+    if !looks_like_sha(rev) {
+        bail!("cannot resolve {rev} into a Git SHA1");
+    }
+    let candidate = repo
+        .rev_parse_single(rev)
+        .map_err(|_| anyhow!("cannot find revision {rev} in remote {remote_name}"))?
+        .detach();
+
+    let prefix = format!("refs/remotes/{remote_name}/");
+    let refs = repo
+        .references()
+        .with_context(|| "Failed to read references")?;
+    let prefixed = refs
+        .prefixed(prefix.as_str())
+        .with_context(|| "Failed to filter references")?;
+    for reference in prefixed {
+        let Ok(mut reference) = reference else {
+            continue;
+        };
+        let Ok(tip_id) = reference.peel_to_id() else {
+            continue;
+        };
+        if let Ok(merge_base) = repo.merge_base(tip_id.detach(), candidate) {
+            if merge_base.detach() == candidate {
+                return Ok(ResolvedRevision {
+                    commit: candidate,
+                    kind: RevisionKind::Sha,
+                });
+            }
+        }
+    }
+
+    bail!("cannot find revision {rev} in remote {remote_name}");
+}
+
+/// Apply a resolved revision: update HEAD (attached for branches, detached
+/// for tags and SHAs) and reset the worktree to the resolved commit's tree.
+fn checkout_revision(repo: &gix::Repository, resolved: &ResolvedRevision, rev: &str) -> Result<()> {
+    match resolved.kind {
+        RevisionKind::Branch => {
+            // Create or reset the local branch to the resolved SHA, then
+            // make HEAD point at the branch ref symbolically.
+            let local_branch = format!("refs/heads/{rev}");
+            let local_branch_name: gix::refs::FullName = local_branch
+                .as_str()
+                .try_into()
+                .map_err(anyhow::Error::new)?;
+            repo.edit_reference(RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: format!("tinty: set {rev} to fetched tip").into(),
+                    },
+                    expected: PreviousValue::Any,
+                    new: Target::Object(resolved.commit),
+                },
+                name: local_branch_name.clone(),
+                deref: false,
+            })
+            .with_context(|| format!("Failed to update {local_branch}"))?;
+            repo.edit_reference(RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: format!("tinty: HEAD → {local_branch}").into(),
+                    },
+                    expected: PreviousValue::Any,
+                    new: Target::Symbolic(local_branch_name),
+                },
+                name: "HEAD".try_into().map_err(anyhow::Error::new)?,
+                deref: false,
+            })
+            .with_context(|| format!("Failed to attach HEAD to {local_branch}"))?;
+        }
+        RevisionKind::Tag | RevisionKind::Sha => {
+            // Detach HEAD onto the (peeled) commit.
+            repo.edit_reference(RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: format!("tinty: detached HEAD onto {rev}").into(),
+                    },
+                    expected: PreviousValue::Any,
+                    new: Target::Object(resolved.commit),
+                },
+                name: "HEAD".try_into().map_err(anyhow::Error::new)?,
+                deref: false,
+            })
+            .with_context(|| format!("Failed to detach HEAD onto {rev}"))?;
+        }
+    }
+    reset_worktree_to(repo, resolved.commit)
+        .with_context(|| format!("Failed to check out worktree at {rev}"))?;
+    Ok(())
 }
 
 /// After `with_ref_name(<tag>)` + clone, gix leaves HEAD symbolically attached
@@ -190,16 +462,6 @@ fn detach_if_tag(repo: &gix::Repository) -> Result<()> {
     Ok(())
 }
 
-/// Picks a sibling backup directory next to `target` for use during `update`.
-fn backup_path_for(target: &Path) -> std::path::PathBuf {
-    let mut name = target.file_name().map_or_else(
-        || std::ffi::OsString::from("repo"),
-        std::ffi::OsString::from,
-    );
-    name.push(".tinty-update-bak");
-    target.with_file_name(name)
-}
-
 /// Returns true iff `rev` is shaped like a (possibly abbreviated) SHA-1.
 /// Mirrors the regex used by the CLI backend: `^[0-9a-f]{1,40}$`.
 fn looks_like_sha(rev: &str) -> bool {
@@ -208,72 +470,6 @@ fn looks_like_sha(rev: &str) -> bool {
         && rev
             .bytes()
             .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-}
-
-/// After a default-branch clone, switch the worktree onto a specific commit
-/// referenced by SHA. Verifies the SHA is reachable from a remote-tracking
-/// branch (matches the CLI backend's containment check) and detaches HEAD.
-fn checkout_sha(repo: &gix::Repository, rev: &str) -> Result<()> {
-    // Resolve the (possibly abbreviated) SHA to a full ObjectId.
-    let candidate = repo
-        .rev_parse_single(rev)
-        .map_err(|_| anyhow!("cannot find revision {rev} in remote origin"))?
-        .detach();
-
-    // Reachability check: the commit must be an ancestor of some
-    // refs/remotes/origin/* tip. Matches the semantic of
-    // `git branch -a --contains <sha>` filtered to that prefix in the CLI
-    // backend.
-    let prefix = "refs/remotes/origin/";
-    let mut reachable = false;
-    let refs = repo
-        .references()
-        .with_context(|| "Failed to read references")?;
-    let prefixed = refs
-        .prefixed(prefix)
-        .with_context(|| "Failed to filter references")?;
-    for reference in prefixed {
-        let Ok(mut reference) = reference else {
-            continue;
-        };
-        // Skip symbolic refs (e.g. `refs/remotes/origin/HEAD` → `…/main`)
-        // by peeling; if peeling fails the ref is unusable for reachability.
-        let Ok(tip_id) = reference.peel_to_id() else {
-            continue;
-        };
-        let tip = tip_id.detach();
-        if let Ok(merge_base) = repo.merge_base(tip, candidate) {
-            if merge_base.detach() == candidate {
-                reachable = true;
-                break;
-            }
-        }
-    }
-    if !reachable {
-        bail!("cannot find revision {rev} in remote origin");
-    }
-
-    // Detach HEAD onto the resolved commit.
-    repo.edit_reference(RefEdit {
-        change: Change::Update {
-            log: LogChange {
-                mode: RefLog::AndReference,
-                force_create_reflog: false,
-                message: format!("tinty: detached HEAD onto {rev}").into(),
-            },
-            expected: PreviousValue::Any,
-            new: Target::Object(candidate),
-        },
-        name: "HEAD".try_into().map_err(anyhow::Error::new)?,
-        deref: false,
-    })
-    .with_context(|| format!("Failed to detach HEAD onto {rev}"))?;
-
-    // Re-materialize the worktree at the new HEAD. Use the index built from
-    // the target tree, then write it through gix's worktree-state checkout.
-    reset_worktree_to(repo, candidate)
-        .with_context(|| format!("Failed to check out worktree at {rev}"))?;
-    Ok(())
 }
 
 /// Materialize the worktree to match the tree of `commit_id`. Rebuilds the
@@ -289,11 +485,9 @@ fn reset_worktree_to(repo: &gix::Repository, commit_id: gix::ObjectId) -> Result
         .with_context(|| format!("Failed to read tree of commit {commit_id}"))?
         .detach();
 
-    // Rebuild the index from the target tree.
-    let index = repo
+    let mut index = repo
         .index_from_tree(&tree_id)
         .with_context(|| format!("Failed to build index from tree {tree_id}"))?;
-    let mut index = index;
 
     let workdir = repo
         .workdir()
@@ -312,7 +506,6 @@ fn reset_worktree_to(repo: &gix::Repository, commit_id: gix::ObjectId) -> Result
     )
     .with_context(|| "Failed to materialize worktree")?;
 
-    // Persist the new index so subsequent `git status` calls have a sane view.
     index
         .write(gix::index::write::Options::default())
         .with_context(|| "Failed to write index")?;

--- a/src/repo/gix.rs
+++ b/src/repo/gix.rs
@@ -1,0 +1,30 @@
+#![allow(clippy::module_name_repetitions)]
+
+use crate::repo::RepositoryBackend;
+use anyhow::{bail, Result};
+use std::path::Path;
+
+/// Repository backend implemented with the pure-Rust `gix` (gitoxide) library.
+///
+/// Phase 2 stub: every method returns an error so the dispatcher path is
+/// reachable but the operations are explicitly not yet wired up. Real
+/// implementations land in Phase 3.
+pub struct GixBackend;
+
+impl RepositoryBackend for GixBackend {
+    fn install(&self, _url: &str, _target: &Path, _revision: Option<&str>) -> Result<()> {
+        bail!(
+            "gix backend: install is not yet implemented (set TINTY_USE_GIX=0 to use the git CLI)"
+        )
+    }
+
+    fn update(&self, _target: &Path, _url: &str, _revision: Option<&str>) -> Result<()> {
+        bail!("gix backend: update is not yet implemented (set TINTY_USE_GIX=0 to use the git CLI)")
+    }
+
+    fn is_clean(&self, _target: &Path) -> Result<bool> {
+        bail!(
+            "gix backend: is_clean is not yet implemented (set TINTY_USE_GIX=0 to use the git CLI)"
+        )
+    }
+}

--- a/src/repo/gix.rs
+++ b/src/repo/gix.rs
@@ -1,14 +1,10 @@
 #![allow(clippy::module_name_repetitions)]
 
 use crate::repo::RepositoryBackend;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::path::Path;
 
 /// Repository backend implemented with the pure-Rust `gix` (gitoxide) library.
-///
-/// Phase 2 stub: every method returns an error so the dispatcher path is
-/// reachable but the operations are explicitly not yet wired up. Real
-/// implementations land in Phase 3.
 pub struct GixBackend;
 
 impl RepositoryBackend for GixBackend {
@@ -22,9 +18,15 @@ impl RepositoryBackend for GixBackend {
         bail!("gix backend: update is not yet implemented (set TINTY_USE_GIX=0 to use the git CLI)")
     }
 
-    fn is_clean(&self, _target: &Path) -> Result<bool> {
-        bail!(
-            "gix backend: is_clean is not yet implemented (set TINTY_USE_GIX=0 to use the git CLI)"
-        )
+    fn is_clean(&self, target: &Path) -> Result<bool> {
+        let repo = gix::open(target)
+            .with_context(|| format!("Failed to open git repository at {}", target.display()))?;
+        // `is_dirty` reports any change to tracked files plus any untracked
+        // (non-ignored) files — equivalent to `git status --porcelain` being
+        // non-empty, which is the contract the CLI backend implements.
+        let dirty = repo
+            .is_dirty()
+            .with_context(|| format!("Failed to read status in {}", target.display()))?;
+        Ok(!dirty)
     }
 }

--- a/src/repo/gix.rs
+++ b/src/repo/gix.rs
@@ -60,19 +60,74 @@ impl RepositoryBackend for GixBackend {
             .with_context(|| format!("Failed to check out worktree at {}", target.display()))?;
 
         if let Some(rev) = revision {
-            if looks_like_sha(rev) {
-                if let Err(e) = checkout_sha(&repo, rev) {
-                    let _ = std::fs::remove_dir_all(target);
-                    return Err(e);
-                }
+            let post = if looks_like_sha(rev) {
+                checkout_sha(&repo, rev)
+            } else {
+                detach_if_tag(&repo)
+            };
+            if let Err(e) = post {
+                let _ = std::fs::remove_dir_all(target);
+                return Err(e);
             }
         }
 
         Ok(())
     }
 
-    fn update(&self, _target: &Path, _url: &str, _revision: Option<&str>) -> Result<()> {
-        bail!("gix backend: update is not yet implemented (set TINTY_USE_GIX=0 to use the git CLI)")
+    /// Update an installed repository to a (possibly new) URL and revision.
+    ///
+    /// Implementation note: rather than mutating the existing repository in
+    /// place (which the CLI backend does via a temp-remote dance to keep
+    /// `.git/config` consistent), we move the existing repo aside, run a
+    /// fresh `install` into the target path, and only delete the moved-aside
+    /// copy on success. On failure we restore the moved-aside copy. This
+    /// gives atomic semantics via filesystem rename without ever touching
+    /// the .git/config file mid-operation, and lets us share all the
+    /// resolve / checkout logic with `install`.
+    fn update(&self, target: &Path, url: &str, revision: Option<&str>) -> Result<()> {
+        if !target.is_dir() {
+            return Err(anyhow!(
+                "Error with updating. {} is not a directory",
+                target.display()
+            ));
+        }
+
+        let backup = backup_path_for(target);
+        if backup.exists() {
+            std::fs::remove_dir_all(&backup).with_context(|| {
+                format!("Failed to remove stale backup at {}", backup.display())
+            })?;
+        }
+        std::fs::rename(target, &backup).with_context(|| {
+            format!(
+                "Failed to move {} aside to {}",
+                target.display(),
+                backup.display()
+            )
+        })?;
+
+        match self.install(url, target, revision) {
+            Ok(()) => {
+                std::fs::remove_dir_all(&backup)
+                    .with_context(|| format!("Failed to remove backup at {}", backup.display()))?;
+                Ok(())
+            }
+            Err(e) => {
+                // Clean up any partial install at the target path, then
+                // restore the original repo from backup.
+                if target.exists() {
+                    let _ = std::fs::remove_dir_all(target);
+                }
+                std::fs::rename(&backup, target).with_context(|| {
+                    format!(
+                        "Failed to restore backup from {} to {} (original error: {e:#})",
+                        backup.display(),
+                        target.display()
+                    )
+                })?;
+                Err(e)
+            }
+        }
     }
 
     /// Reports whether the working directory is clean.
@@ -98,6 +153,51 @@ impl RepositoryBackend for GixBackend {
         let any_change = iter.next().is_some();
         Ok(!any_change)
     }
+}
+
+/// After `with_ref_name(<tag>)` + clone, gix leaves HEAD symbolically attached
+/// to the tag ref (`refs/tags/<tag>`). For annotated tags this means
+/// `git rev-parse HEAD` resolves to the tag object's SHA rather than the
+/// underlying commit's SHA, which differs from what `git checkout <tag>`
+/// produces (detached HEAD at the commit). This helper detects that state
+/// and detaches HEAD onto the peeled commit so behavior matches.
+fn detach_if_tag(repo: &gix::Repository) -> Result<()> {
+    let Ok(Some(mut reference)) = repo.head_ref() else {
+        return Ok(());
+    };
+    if !reference.name().as_bstr().starts_with(b"refs/tags/") {
+        return Ok(());
+    }
+    let name = reference.name().as_bstr().to_owned();
+    let commit_id = reference
+        .peel_to_id()
+        .with_context(|| format!("Failed to peel {name} to a commit"))?
+        .detach();
+    repo.edit_reference(RefEdit {
+        change: Change::Update {
+            log: LogChange {
+                mode: RefLog::AndReference,
+                force_create_reflog: false,
+                message: format!("tinty: detached HEAD onto {name}").into(),
+            },
+            expected: PreviousValue::Any,
+            new: Target::Object(commit_id),
+        },
+        name: "HEAD".try_into().map_err(anyhow::Error::new)?,
+        deref: false,
+    })
+    .with_context(|| format!("Failed to detach HEAD from {name}"))?;
+    Ok(())
+}
+
+/// Picks a sibling backup directory next to `target` for use during `update`.
+fn backup_path_for(target: &Path) -> std::path::PathBuf {
+    let mut name = target.file_name().map_or_else(
+        || std::ffi::OsString::from("repo"),
+        std::ffi::OsString::from,
+    );
+    name.push(".tinty-update-bak");
+    target.with_file_name(name)
 }
 
 /// Returns true iff `rev` is shaped like a (possibly abbreviated) SHA-1.

--- a/src/repo/gix.rs
+++ b/src/repo/gix.rs
@@ -2,6 +2,8 @@
 
 use crate::repo::RepositoryBackend;
 use anyhow::{anyhow, bail, Context, Result};
+use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
+use gix::refs::Target;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
@@ -18,22 +20,54 @@ impl RepositoryBackend for GixBackend {
             ));
         }
 
-        if revision.is_some() {
-            bail!(
-                "gix backend: install with a pinned revision is not yet implemented \
-                 (set TINTY_USE_GIX=0 to use the git CLI)"
-            );
-        }
-
         let interrupt = AtomicBool::new(false);
         let mut prepare = gix::prepare_clone(url, target)
             .with_context(|| format!("Failed to set up clone of {url}"))?;
-        let (mut checkout, _outcome) = prepare
-            .fetch_then_checkout(gix::progress::Discard, &interrupt)
-            .with_context(|| format!("Failed to clone repository from {url}"))?;
-        checkout
+
+        // For tag- or branch-named revisions, point gix at the requested ref
+        // up front so the clone fetches and checks it out in one step. This
+        // also gets HEAD attached when the ref is a branch, matching what
+        // `git clone --branch` does. SHA revisions don't go through this
+        // path because they aren't a ref name; they fall through to the
+        // post-fetch resolve-and-checkout below.
+        if let Some(rev) = revision {
+            if !looks_like_sha(rev) {
+                prepare = prepare
+                    .with_ref_name(Some(rev))
+                    .with_context(|| format!("Failed to target revision {rev} on remote {url}"))?;
+            }
+        }
+
+        let fetch_result = prepare.fetch_then_checkout(gix::progress::Discard, &interrupt);
+        let (mut checkout, _outcome) = match fetch_result {
+            Ok(t) => t,
+            Err(e) => {
+                // For non-SHA revisions, gix surfaces an error like
+                // "The remote didn't have any ref that matched '<rev>'"
+                // when neither a tag nor a branch matches. Normalize to the
+                // CLI backend's wording so callers (and tests) see the same
+                // message regardless of which backend ran.
+                if let Some(rev) = revision {
+                    if !looks_like_sha(rev) && format!("{e:#}").contains("didn't have any ref") {
+                        bail!("cannot resolve {rev} into a Git SHA1");
+                    }
+                }
+                return Err(e).with_context(|| format!("Failed to clone repository from {url}"));
+            }
+        };
+        let (repo, _) = checkout
             .main_worktree(gix::progress::Discard, &interrupt)
             .with_context(|| format!("Failed to check out worktree at {}", target.display()))?;
+
+        if let Some(rev) = revision {
+            if looks_like_sha(rev) {
+                if let Err(e) = checkout_sha(&repo, rev) {
+                    let _ = std::fs::remove_dir_all(target);
+                    return Err(e);
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -64,4 +98,124 @@ impl RepositoryBackend for GixBackend {
         let any_change = iter.next().is_some();
         Ok(!any_change)
     }
+}
+
+/// Returns true iff `rev` is shaped like a (possibly abbreviated) SHA-1.
+/// Mirrors the regex used by the CLI backend: `^[0-9a-f]{1,40}$`.
+fn looks_like_sha(rev: &str) -> bool {
+    !rev.is_empty()
+        && rev.len() <= 40
+        && rev
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// After a default-branch clone, switch the worktree onto a specific commit
+/// referenced by SHA. Verifies the SHA is reachable from a remote-tracking
+/// branch (matches the CLI backend's containment check) and detaches HEAD.
+fn checkout_sha(repo: &gix::Repository, rev: &str) -> Result<()> {
+    // Resolve the (possibly abbreviated) SHA to a full ObjectId.
+    let candidate = repo
+        .rev_parse_single(rev)
+        .map_err(|_| anyhow!("cannot find revision {rev} in remote origin"))?
+        .detach();
+
+    // Reachability check: the commit must be an ancestor of some
+    // refs/remotes/origin/* tip. Matches the semantic of
+    // `git branch -a --contains <sha>` filtered to that prefix in the CLI
+    // backend.
+    let prefix = "refs/remotes/origin/";
+    let mut reachable = false;
+    let refs = repo
+        .references()
+        .with_context(|| "Failed to read references")?;
+    let prefixed = refs
+        .prefixed(prefix)
+        .with_context(|| "Failed to filter references")?;
+    for reference in prefixed {
+        let Ok(mut reference) = reference else {
+            continue;
+        };
+        // Skip symbolic refs (e.g. `refs/remotes/origin/HEAD` → `…/main`)
+        // by peeling; if peeling fails the ref is unusable for reachability.
+        let Ok(tip_id) = reference.peel_to_id() else {
+            continue;
+        };
+        let tip = tip_id.detach();
+        if let Ok(merge_base) = repo.merge_base(tip, candidate) {
+            if merge_base.detach() == candidate {
+                reachable = true;
+                break;
+            }
+        }
+    }
+    if !reachable {
+        bail!("cannot find revision {rev} in remote origin");
+    }
+
+    // Detach HEAD onto the resolved commit.
+    repo.edit_reference(RefEdit {
+        change: Change::Update {
+            log: LogChange {
+                mode: RefLog::AndReference,
+                force_create_reflog: false,
+                message: format!("tinty: detached HEAD onto {rev}").into(),
+            },
+            expected: PreviousValue::Any,
+            new: Target::Object(candidate),
+        },
+        name: "HEAD".try_into().map_err(anyhow::Error::new)?,
+        deref: false,
+    })
+    .with_context(|| format!("Failed to detach HEAD onto {rev}"))?;
+
+    // Re-materialize the worktree at the new HEAD. Use the index built from
+    // the target tree, then write it through gix's worktree-state checkout.
+    reset_worktree_to(repo, candidate)
+        .with_context(|| format!("Failed to check out worktree at {rev}"))?;
+    Ok(())
+}
+
+/// Materialize the worktree to match the tree of `commit_id`. Rebuilds the
+/// index from that tree and runs gix's worktree-state checkout to write
+/// every file.
+fn reset_worktree_to(repo: &gix::Repository, commit_id: gix::ObjectId) -> Result<()> {
+    let commit = repo
+        .find_object(commit_id)
+        .with_context(|| format!("Failed to find commit {commit_id}"))?
+        .into_commit();
+    let tree_id = commit
+        .tree_id()
+        .with_context(|| format!("Failed to read tree of commit {commit_id}"))?
+        .detach();
+
+    // Rebuild the index from the target tree.
+    let index = repo
+        .index_from_tree(&tree_id)
+        .with_context(|| format!("Failed to build index from tree {tree_id}"))?;
+    let mut index = index;
+
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow!("Repository has no working directory"))?
+        .to_owned();
+
+    let opts = gix::worktree::state::checkout::Options::default();
+    gix::worktree::state::checkout(
+        &mut index,
+        &workdir,
+        repo.objects.clone().into_arc()?,
+        &gix::progress::Discard,
+        &gix::progress::Discard,
+        &AtomicBool::new(false),
+        opts,
+    )
+    .with_context(|| "Failed to materialize worktree")?;
+
+    // Persist the new index so subsequent `git status` calls have a sane view.
+    index
+        .write(gix::index::write::Options::default())
+        .with_context(|| "Failed to write index")?;
+
+    Ok(())
 }

--- a/src/repo/gix.rs
+++ b/src/repo/gix.rs
@@ -78,18 +78,29 @@ impl RepositoryBackend for GixBackend {
 
     /// Update an installed repository to a (possibly new) URL and revision.
     ///
-    /// Validate-first design:
+    /// Stage-then-promote design — every step that can fail does so before
+    /// any user-visible promotion. `.git/config` and `refs/remotes/origin/*`
+    /// stay at the OLD state until the very last steps:
     ///
-    /// 1. ls-refs against the new URL via an in-memory anonymous remote.
-    ///    This bails before any local mutation if the requested tag/branch
-    ///    doesn't exist on the remote (and the revision isn't a SHA we can
-    ///    verify post-fetch).
-    /// 2. If the URL changed, write the new URL to `.git/config`. The
-    ///    original URL is kept in memory for rollback.
-    /// 3. Fetch from origin, resolve the revision against local refs, and
-    ///    update HEAD + worktree.
-    /// 4. On any failure during step 3, restore the original URL in
-    ///    `.git/config` and propagate the error.
+    /// 1. **Probe.** ls-refs against the new URL via an in-memory remote.
+    ///    Bails before any local mutation if the requested tag/branch
+    ///    doesn't exist (and the revision isn't a SHA we can verify
+    ///    post-fetch).
+    /// 2. **Fetch into staging.** Pull objects + refs through the in-memory
+    ///    remote into `refs/remotes/tinty-update/*`. Origin stays unchanged.
+    /// 3. **Resolve in staging.** Tag/branch lookup against
+    ///    `refs/tags/*` and `refs/remotes/tinty-update/*`; SHA reachability
+    ///    via `merge_base`.
+    /// 4. **Materialize the worktree.** Most failure-prone step. If this
+    ///    fails, `.git/HEAD` and `refs/remotes/origin/*` are unchanged —
+    ///    git still truthfully reports the OLD state.
+    /// 5. **Atomic ref transaction.** Promote staging refs to
+    ///    `refs/remotes/origin/*` and update HEAD in a single
+    ///    `edit_references` batch. After this, the repo is at the new
+    ///    state from git's perspective.
+    /// 6. **Write origin URL.** Only if changed. Last step so a failure
+    ///    here just leaves a config that will be reconciled on the next
+    ///    `tinty update`.
     fn update(&self, target: &Path, url: &str, revision: Option<&str>) -> Result<()> {
         if !target.is_dir() {
             return Err(anyhow!(
@@ -98,51 +109,35 @@ impl RepositoryBackend for GixBackend {
             ));
         }
 
-        let mut repo = gix::open(target)
+        let repo = gix::open(target)
             .with_context(|| format!("Failed to open git repository at {}", target.display()))?;
         let rev_str = revision.unwrap_or("main");
 
-        // Phase 1: ls-refs against the new URL — no local mutation yet.
+        // 1. Probe.
         let _kind_hint = probe_revision_kind_at(&repo, url, rev_str)?;
 
-        // Phase 2: capture the current origin URL and switch to the new one
-        // if it changed. The captured URL is used for rollback if the work
-        // below fails.
+        // 2. Fetch via in-memory remote into staging.
+        fetch_to_staging(&repo, url)?;
+
+        // 3. Resolve revision against the staging namespace.
+        let resolved = resolve_revision(&repo, "tinty-update", rev_str)?;
+
+        // 4. Materialize the worktree first. If this fails, .git/ is intact.
+        reset_worktree_to(&repo, resolved.commit)
+            .with_context(|| format!("Failed to check out worktree at {rev_str}"))?;
+
+        // 5. Atomic ref transaction: promote staging → origin and update HEAD.
+        promote_and_set_head(&repo, &resolved, rev_str)?;
+
+        // 6. Persist the new origin URL last. A failure here leaves the repo
+        // at the new state ref-wise but with a stale config URL; the next
+        // `tinty update` will reconcile.
         let old_url = read_origin_url(&repo)?;
-        let url_changed = old_url.as_bstr() != url.as_bytes().as_bstr();
-        if url_changed {
+        if old_url.as_bstr() != url.as_bytes().as_bstr() {
             write_origin_url(&repo, url)?;
-            repo = gix::open(target).with_context(|| {
-                format!(
-                    "Failed to re-open repository after URL update at {}",
-                    target.display()
-                )
-            })?;
         }
 
-        // Phase 3: fetch + resolve + checkout. Encapsulated so we can run
-        // rollback on any failure.
-        let do_work = || -> Result<()> {
-            fetch_origin(&repo)?;
-            let resolved = resolve_revision(&repo, "origin", rev_str)?;
-            checkout_revision(&repo, &resolved, rev_str)?;
-            Ok(())
-        };
-
-        match do_work() {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                if url_changed {
-                    let restored = std::str::from_utf8(old_url.as_ref())
-                        .map(str::to_owned)
-                        .ok();
-                    if let Some(orig) = restored {
-                        let _ = write_origin_url(&repo, &orig);
-                    }
-                }
-                Err(e)
-            }
-        }
+        Ok(())
     }
 
     /// Reports whether the working directory is clean.
@@ -268,25 +263,166 @@ fn write_origin_url(repo: &gix::Repository, url: &str) -> Result<()> {
     Ok(())
 }
 
-/// Fetch from the configured `origin` remote, updating `refs/remotes/origin/*`
-/// and `refs/tags/*` per the existing refspecs in `.git/config`.
-fn fetch_origin(repo: &gix::Repository) -> Result<()> {
+/// Refspec namespace tinty uses for "staging" remote-tracking branches
+/// during an update before promoting them onto `refs/remotes/origin/*`.
+const STAGING_PREFIX: &str = "refs/remotes/tinty-update/";
+
+/// Fetch into a staging refspec (`refs/remotes/tinty-update/*`) via an
+/// in-memory anonymous remote at `url`. Objects land in the local
+/// objectdb (idempotent — they're content-addressed). Branch refs land
+/// in the staging namespace so existing `refs/remotes/origin/*` refs are
+/// untouched until the caller explicitly promotes them. Tags fetch into
+/// `refs/tags/*` (force-overwrite); they don't have a standard
+/// remote-tracking namespace, and for tinty's "this URL is now the
+/// source of truth" semantics, overwriting matches user intent.
+fn fetch_to_staging(repo: &gix::Repository, url: &str) -> Result<()> {
     let interrupt = AtomicBool::new(false);
     let remote = repo
-        .find_remote("origin")
-        .with_context(|| "Failed to find origin remote")?;
+        .remote_at(url)
+        .with_context(|| format!("Failed to build in-memory remote at {url}"))?
+        .with_refspecs(
+            [
+                "+refs/heads/*:refs/remotes/tinty-update/*",
+                "+refs/tags/*:refs/tags/*",
+            ],
+            Direction::Fetch,
+        )
+        .with_context(|| "Failed to set staging refspecs on update remote")?;
     let connection = remote
         .connect(Direction::Fetch)
-        .with_context(|| "Failed to connect to origin")?;
+        .with_context(|| format!("Failed to connect to {url}"))?;
     let prepare = connection
         .prepare_fetch(
             gix::progress::Discard,
             gix::remote::ref_map::Options::default(),
         )
-        .with_context(|| "Failed to prepare fetch from origin")?;
+        .with_context(|| format!("Failed to prepare fetch from {url}"))?;
     prepare
         .receive(gix::progress::Discard, &interrupt)
-        .with_context(|| "Failed to receive objects from origin")?;
+        .with_context(|| format!("Failed to receive objects from {url}"))?;
+    Ok(())
+}
+
+/// Atomically promote the staging refs into `refs/remotes/origin/*` and
+/// set HEAD to the resolved revision, in a single ref transaction. If
+/// gix can't apply the whole batch atomically, it applies none of it,
+/// leaving the staging refs in place for the next attempt.
+#[allow(clippy::too_many_lines)]
+fn promote_and_set_head(
+    repo: &gix::Repository,
+    resolved: &ResolvedRevision,
+    rev: &str,
+) -> Result<()> {
+    let mut edits: Vec<RefEdit> = Vec::new();
+
+    // For every staging branch ref: write it to refs/remotes/origin/<name>
+    // and delete the staging copy. PreviousValue::Any so we overwrite
+    // whatever was there.
+    let refs = repo
+        .references()
+        .with_context(|| "Failed to read references")?;
+    let prefixed = refs
+        .prefixed(STAGING_PREFIX)
+        .with_context(|| "Failed to filter staging references")?;
+    for reference in prefixed {
+        let Ok(mut reference) = reference else {
+            continue;
+        };
+        let staging_name = reference.name().as_bstr().to_owned();
+        let suffix = match staging_name.strip_prefix(STAGING_PREFIX.as_bytes()) {
+            Some(s) => s.to_owned(),
+            None => continue,
+        };
+        let Ok(tip) = reference.peel_to_id() else {
+            continue;
+        };
+        let tip_oid = tip.detach();
+
+        let mut origin_name_bytes = b"refs/remotes/origin/".to_vec();
+        origin_name_bytes.extend_from_slice(&suffix);
+        let origin_full: gix::refs::FullName = gix::bstr::BStr::new(&origin_name_bytes)
+            .try_into()
+            .map_err(anyhow::Error::new)?;
+        let staging_full: gix::refs::FullName = staging_name
+            .as_bstr()
+            .try_into()
+            .map_err(anyhow::Error::new)?;
+
+        edits.push(RefEdit {
+            change: Change::Update {
+                log: LogChange {
+                    mode: RefLog::AndReference,
+                    force_create_reflog: false,
+                    message: format!("tinty: promote {origin_full}").into(),
+                },
+                expected: PreviousValue::Any,
+                new: Target::Object(tip_oid),
+            },
+            name: origin_full,
+            deref: false,
+        });
+        edits.push(RefEdit {
+            change: Change::Delete {
+                expected: PreviousValue::Any,
+                log: RefLog::AndReference,
+            },
+            name: staging_full,
+            deref: false,
+        });
+    }
+
+    // HEAD edits, batched into the same transaction.
+    match resolved.kind {
+        RevisionKind::Branch => {
+            let local = format!("refs/heads/{rev}");
+            let local_full: gix::refs::FullName =
+                local.as_str().try_into().map_err(anyhow::Error::new)?;
+            edits.push(RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: format!("tinty: set {rev} to fetched tip").into(),
+                    },
+                    expected: PreviousValue::Any,
+                    new: Target::Object(resolved.commit),
+                },
+                name: local_full.clone(),
+                deref: false,
+            });
+            edits.push(RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: format!("tinty: HEAD → {local}").into(),
+                    },
+                    expected: PreviousValue::Any,
+                    new: Target::Symbolic(local_full),
+                },
+                name: "HEAD".try_into().map_err(anyhow::Error::new)?,
+                deref: false,
+            });
+        }
+        RevisionKind::Tag | RevisionKind::Sha => {
+            edits.push(RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: format!("tinty: detached HEAD onto {rev}").into(),
+                    },
+                    expected: PreviousValue::Any,
+                    new: Target::Object(resolved.commit),
+                },
+                name: "HEAD".try_into().map_err(anyhow::Error::new)?,
+                deref: false,
+            });
+        }
+    }
+
+    repo.edit_references(edits)
+        .with_context(|| "Failed to promote staging refs and update HEAD atomically")?;
     Ok(())
 }
 
@@ -363,9 +499,16 @@ fn resolve_revision(
     bail!("cannot find revision {rev} in remote {remote_name}");
 }
 
-/// Apply a resolved revision: update HEAD (attached for branches, detached
-/// for tags and SHAs) and reset the worktree to the resolved commit's tree.
+/// Apply a resolved revision. Materialize the worktree first (the most
+/// failure-prone step), then update HEAD as a single bookkeeping step that
+/// "promotes" the operation. If the worktree materialization fails partway,
+/// `.git/HEAD` and `refs/heads/*` still describe the old state — the user
+/// or a follow-up `tinty apply` / `tinty update` can recover by re-checking
+/// out the (still-old) HEAD over the partial worktree.
 fn checkout_revision(repo: &gix::Repository, resolved: &ResolvedRevision, rev: &str) -> Result<()> {
+    reset_worktree_to(repo, resolved.commit)
+        .with_context(|| format!("Failed to check out worktree at {rev}"))?;
+
     match resolved.kind {
         RevisionKind::Branch => {
             // Create or reset the local branch to the resolved SHA, then
@@ -422,8 +565,6 @@ fn checkout_revision(repo: &gix::Repository, resolved: &ResolvedRevision, rev: &
             .with_context(|| format!("Failed to detach HEAD onto {rev}"))?;
         }
     }
-    reset_worktree_to(repo, resolved.commit)
-        .with_context(|| format!("Failed to check out worktree at {rev}"))?;
     Ok(())
 }
 


### PR DESCRIPTION
### Description

Phase 2 of the gix migration — pulls `gix` into the binary, wires up the dispatch path, and implements the full `RepositoryBackend` against the gix path. Default backend stays CLI; `TINTY_USE_GIX=1` opts in.

`Cargo.toml` gets `gix = "0.83"` with `default-features = false` and a minimal feature set (reqwest-rust-tls for HTTPS, plus worktree-mutation, status, sha1, max-performance-safe, revision). Had to relax the `tempfile = "=3.6.0"` exact pin to `"3"` because `gix-odb` needs `^3.26`.

The dispatcher lives in `src/repo.rs` (note: phase 1 originally landed as `src/repo/mod.rs`; reworked here to the file-as-module convention per review feedback). It reads `TINTY_USE_GIX` and picks `GixBackend` when truthy. Default stays CLI.

The biggest policy proposal: `cmake` is no longer banned. The chain that forces it is `gix → reqwest → rustls → aws-lc-rs → aws-lc-sys`, and `aws-lc-sys` uses `cmake` to build. There's no `-rust-tls-ring` feature variant in `gix 0.83` that avoids `aws-lc-rs`, and switching to `blocking-http-transport-curl-rustls` is strictly worse (still pulls `aws-lc-rs` and adds `curl-sys` on top). The principled bans on `openssl`, `openssl-sys`, and `libssh2-sys` all stay. `windows` stays banned too. We can revisit once gitoxide ships a ring variant?

The license allow-list picks up `ISC` (rustls-webpki, aws-lc-rs) and `MIT-0` (aws-lc-sys). Dropped the old `bitflags` skip since it was tied to the now-relaxed tempfile pin.

All three `RepositoryBackend` methods are now implemented for the gix path. `install` goes through `gix::prepare_clone` for the no-revision case, and `with_ref_name` for tag/branch revisions; annotated tags get a small post-clone fixup so `git rev-parse HEAD` returns the underlying commit's SHA rather than the tag-object SHA. SHA revisions take a two-step path: clone the default branch, verify the SHA is reachable from a `refs/remotes/origin/*` tip via `merge_base`, then detach HEAD and rebuild the worktree from the resolved tree.

`update` went through a few iterations and landed on a stage-then-promote design. It probes the remote (anonymous, no-disk-side-effects) to validate the revision exists, fetches into a staging refspec (`refs/remotes/tinty-update/*`) on the existing repo, resolves the revision in staging, materializes the worktree from staging, then atomically promotes staging refs to `refs/remotes/origin/*` plus updates HEAD via a single ref transaction. The origin URL is written last (only if it changed), so if anything fails before promotion the existing repo is untouched. No filesystem rename, no temp clone, no rollback path needed for the common case.

`is_clean` deliberately diverges from the CLI backend: it ignores untracked files. The CLI uses `git status --porcelain` which counts untracked entries; the gix backend sets `UntrackedFiles::None`. This effectively fixes #130 for users who opt into the gix backend — `tinty generate-scheme` artifacts no longer block `tinty update` / `tinty sync`.

Existing test suite passes on both backends end-to-end: 112 tests across 17 suites, with the same expected outputs whether `TINTY_USE_GIX=1` is set or unset. A dedicated cross-backend parity test suite (the original plan's Phase 4) isn't in this PR.
