### PR TITLE
Fix `tinty current <property>` failing on non-YAML files in schemes repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fix `tinty current <property>` failing with `E111: Invalid scheme file extension` 
+  when the schemes repo contains non-YAML files (e.g. `LICENSE`, `README.md`)
+  at its root.
+
 ## [0.32.2] - 2026-05-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- **BREAKING**: `tinty current <property>` now only discovers schemes under
+  the `base16/`/`base24/`/`tinted8/` subdirectories of the schemes repo and
+  custom-schemes directory, matching how `tinty apply` and `tinty list`
+  already work. Previously it walked the schemes repo recursively from the
+  root. Custom schemes laid flat at the root of `custom-schemes/` (rather
+  than under `custom-schemes/<system>/`) will no longer be resolved by
+  `current <property>`; this matches the layout `apply` has always required.
+
 ### Fixed
 
 - Fix `tinty current <property>` failing with `E111: Invalid scheme file extension` 

--- a/src/operations/current.rs
+++ b/src/operations/current.rs
@@ -2,10 +2,10 @@ use crate::constants::{
     ARTIFACTS_DIR, CURRENT_SCHEME_FILE_NAME, CUSTOM_SCHEMES_DIR_NAME, REPO_DIR, REPO_NAME,
     SCHEMES_REPO_NAME,
 };
+use crate::utils::get_all_scheme_file_paths;
 use anyhow::{anyhow, Result};
 use std::fs;
 use std::path::Path;
-use tinted_builder_rust::utils::get_scheme_files;
 
 pub fn get_current_scheme_slug(data_path: &Path) -> String {
     fs::read_to_string(data_path.join(ARTIFACTS_DIR).join(CURRENT_SCHEME_FILE_NAME))
@@ -36,39 +36,15 @@ pub fn current(data_path: &Path, property_name: &str) -> Result<()> {
     }
 
     let custom_schemes_path = data_path.join(CUSTOM_SCHEMES_DIR_NAME);
-    let scheme_files = {
-        let mut scheme_files = get_scheme_files(&schemes_path, &[], true)?;
+    let mut scheme_files = get_all_scheme_file_paths(&schemes_path, None)?;
+    if custom_schemes_path.is_dir() {
+        let custom_scheme_files = get_all_scheme_file_paths(&custom_schemes_path, None)?;
+        scheme_files.extend(custom_scheme_files);
+    }
 
-        if custom_schemes_path.is_dir() {
-            let custom_scheme_files = get_scheme_files(&custom_schemes_path, &[], true)?;
-            scheme_files.extend(custom_scheme_files);
-        }
-
-        scheme_files
-    };
-
-    let current_scheme_container = scheme_files.iter().find_map(|scheme_file| {
-        let path = scheme_file.get_path();
-        let file_stem = path
-            .file_stem()
-            .unwrap_or_default()
-            .to_str()
-            .unwrap_or_default();
-
-        if current_scheme_slug.ends_with(file_stem) {
-            if let Ok(scheme) = scheme_file.get_scheme() {
-                let scheme_slug = scheme.get_scheme_slug();
-                let system = scheme.get_scheme_system();
-                let tinty_slug = format!("{system}-{scheme_slug}");
-
-                if tinty_slug == current_scheme_slug {
-                    return Some(scheme);
-                }
-            }
-        }
-
-        None
-    });
+    let current_scheme_container = scheme_files
+        .get(&current_scheme_slug)
+        .and_then(|scheme_file| scheme_file.get_scheme().ok());
 
     if let Some(current_scheme_container) = current_scheme_container {
         match property_name.trim() {

--- a/tests/cli_current_subcommand_tests.rs
+++ b/tests/cli_current_subcommand_tests.rs
@@ -25,7 +25,7 @@ fn test_cli_current_subcommand_with_setup() -> Result<()> {
     let schemes_dir = data_path.join(format!("{REPO_DIR}/{SCHEMES_REPO_NAME}"));
 
     write_to_file(&current_scheme_path, scheme_name)?;
-    copy_dir_all("./tests/fixtures/schemes", schemes_dir)?;
+    copy_dir_all("./tests/fixtures/schemes", schemes_dir.join("base16"))?;
 
     // ---
     // Act
@@ -114,7 +114,7 @@ where
     let schemes_dir = data_path.join(format!("{REPO_DIR}/{SCHEMES_REPO_NAME}"));
 
     write_to_file(&current_scheme_path, scheme_name)?;
-    copy_dir_all("./tests/fixtures/schemes", schemes_dir)?;
+    copy_dir_all("./tests/fixtures/schemes", schemes_dir.join("base16"))?;
 
     // ---
     // Act


### PR DESCRIPTION
## Summary

- `tinty current variant` (and `system`/`name`/`author`/`description`/`slug`) failed with `E111: Invalid scheme file extension: …/repos/schemes/LICENSE` because `src/operations/current.rs` called `tinted_builder_rust::utils::get_scheme_files(&schemes_path, &[], true)` against the schemes repo root, and the upstream walker is strict — any non-`.yaml`/`.yml` entry (`LICENSE`, `README.md`, `BASE16.md`, `scripts/`) aborts traversal with E111.
- Switched to the project's own `get_all_scheme_file_paths()` helper (already used by `list.rs` and `apply.rs`), which only walks the known `base16/`/`base24/`/`tinted8/` subdirs and silently drops unrecognized entries.
- Lookup simplifies to a direct `HashMap.get(&current_scheme_slug)` since the helper keys by `{system}-{slug}` — same format as the persisted current-scheme slug.

## Test plan

- [x] `cargo build`
- [x] `tinty current` (no arg) — prints slug
- [x] `tinty current variant` — prints `dark`
- [x] `tinty current system` — prints `base16`
- [x] `tinty current name` — prints `Gruvbox dark, hard`
- [x] `cargo test`