### PR TITLE
ci: fix cargo-about/cargo-deny install in release workflow

### DIFF
--- a/.github/workflows/create-release-commit.yml
+++ b/.github/workflows/create-release-commit.yml
@@ -79,15 +79,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: "Install tinted-builder-rust"
-        uses: "jaxxstorm/action-install-gh-release@v1.10.0"
-        with: # Get the latest cargo-about release
-          repo: "EmbarkStudios/cargo-about"
-
-      - name: "Install tinted-builder-rust"
-        uses: "jaxxstorm/action-install-gh-release@v1.10.0"
-        with: # Get the latest cargo-deny release
-          repo: "EmbarkStudios/cargo-deny"
+      - name: Install cargo-about and cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-about,cargo-deny
 
       - name: Add release changes to CHANGELOG.md
         if: ${{ steps.search_commit.outputs.hash == '' }}


### PR DESCRIPTION
## Problem

The `create-release-commit` job [fails](https://github.com/tinted-theming/tinty/actions/runs/27178037687/job/80231177659) at the "Install tinted-builder-rust" step:

```
Automatically extracted release asset cargo-about-0.9.0-x86_64-unknown-linux-musl.tar.gz
  to /opt/hostedtoolcache/EmbarkStudios/cargo-about/latest/linux-x64
##[error]No files found in /opt/hostedtoolcache/EmbarkStudios/cargo-about/latest/linux-x64
```

`cargo-about`'s release tarball nests the binary inside a versioned subdirectory (`cargo-about-<version>-<target>/cargo-about`), which `jaxxstorm/action-install-gh-release@v1.10.0` does not search — it only looks at the archive root. This affected every cargo-about version, so the approach introduced in #164 never actually worked; it only surfaced now because that step runs solely in the `workflow_dispatch` release path.

## Fix

Replace the two duplicate, mislabeled `"Install tinted-builder-rust"` steps with a single `taiki-e/install-action@v2` step. It has first-class support for both tools, fetches prebuilt binaries (preserving #164's goal of skipping compilation), and handles the nested archive layout.

```yaml
- name: Install cargo-about and cargo-deny
  uses: taiki-e/install-action@v2
  with:
    tool: cargo-about,cargo-deny
```