### PR TITLE
fix(build): skip non-scheme files in the schemes repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fix `tinty build` failing with `E111: Invalid scheme file extension` when the
+  schemes repo contains non-scheme files (e.g. `LICENSE`, `README.md`) at its
+  root.
+
 ## [0.33.0] - 2026-06-09
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "tinted-builder-rust"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b3b05445e671a8206c48089ca3eb7231b4bd8752946e03a3d5a29b314b0d7d"
+checksum = "35f07b56ec9e04193a6711a34cb3c2e5e73dbbf60e0faf0d72c3e16a7956dcd5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_yaml = "0.9.34"
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
 shell-words = "1.1.1"
 strip-ansi-escapes = "0.2.1"
-tinted-builder-rust = "0.20.1"
+tinted-builder-rust = "0.21.0"
 tinted-builder = "0.16.0"
 tinted-scheme-extractor = "0.13.0"
 toml = "0.8.23"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use tinted_builder::SchemeSystem;
-use tinted_builder_rust::operation_build::utils::SchemeFile;
+use tinted_builder_rust::operation_build::utils::{get_scheme_files_by_name, SchemeFile};
 
 /// Ensures that a directory exists, creating it if it does not.
 pub fn ensure_directory_exists<P: AsRef<Path>>(dir_path: P) -> Result<()> {
@@ -78,36 +78,10 @@ pub fn get_all_scheme_file_paths(
         ));
     }
 
-    let mut scheme_files: HashMap<String, SchemeFile> = HashMap::new();
-
-    // For each supported scheme system, add schemes to vec
-    let scheme_systems =
-        scheme_systems_option.map_or_else(|| SchemeSystem::variants().to_vec(), |s| vec![s]);
-    for scheme_system in scheme_systems {
-        let scheme_system_dir = schemes_path.join(scheme_system.as_str());
-        if !scheme_system_dir.exists() {
-            continue;
-        }
-
-        let files = fs::read_dir(&scheme_system_dir)?
-            // Discard failed read results
-            .filter_map(Result::ok)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .filter_map(|file| {
-                // Convert batch of files into a HashMap<String, SchemeFile>, where
-                // the key is the scheme's <system>-<slug> e.g. base16-github
-                // Map each entry into a (<String, SchemaFile) tuple that
-                // we can collect() into this batch's HashMap<String, SchemaFile>
-                let name = format!("{scheme_system}-{}", file.path().file_stem()?.to_str()?);
-                let scheme_file = SchemeFile::new(file.path().as_path()).ok()?;
-
-                Some((name, scheme_file))
-            })
-            .collect::<HashMap<String, SchemeFile>>();
-        scheme_files.extend(files);
-    }
-    Ok(scheme_files)
+    // Delegate the actual `<system>/`-subdir walk to tinted-builder-rust so the
+    // scheme-discovery logic lives in one place. This keeps tinty's friendly
+    // "run install" error while sharing the keyed (`<system>-<slug>`) lookup.
+    get_scheme_files_by_name(schemes_path, scheme_systems_option)
 }
 
 pub fn replace_tilde_slash_with_home(path_str: &str) -> Result<PathBuf> {

--- a/tests/cli_build_subcommand_tests.rs
+++ b/tests/cli_build_subcommand_tests.rs
@@ -1,0 +1,69 @@
+//! Integration tests for the `build` subcommand.
+//!
+//! Covers building a template against the synced schemes repo, including the
+//! regression where non-scheme files at the schemes-repo root (e.g. `LICENSE`,
+//! `README.md`) caused `build` to fail with `E111`.
+
+mod utils;
+
+use crate::utils::{build_command_vec, run_command, write_to_file, REPO_DIR, SCHEMES_REPO_NAME};
+use anyhow::Result;
+use std::fs;
+
+#[test]
+fn test_cli_build_ignores_non_scheme_files_in_schemes_repo() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let temp_dir = tempfile::Builder::new()
+        .prefix("tinty-test-build-")
+        .tempdir()?;
+    let config_path = temp_dir.path().join("config.toml");
+    let data_path = temp_dir.path().join("data");
+    let schemes_repo = data_path.join(REPO_DIR).join(SCHEMES_REPO_NAME);
+
+    // A real base16 scheme under `base16/`, alongside non-scheme files at the
+    // schemes-repo root that previously made `build` fail with E111.
+    let scheme = fs::read_to_string("./tests/fixtures/schemes/tinty-generated.yaml")?;
+    write_to_file(
+        schemes_repo.join("base16").join("tinty-generated.yaml"),
+        &scheme,
+    )?;
+    write_to_file(schemes_repo.join("LICENSE"), "license text")?;
+    write_to_file(schemes_repo.join("README.md"), "# readme")?;
+
+    // A minimal base16 template.
+    let template_dir = temp_dir.path().join("template");
+    write_to_file(
+        template_dir.join("templates").join("config.yaml"),
+        "base16-test:\n  filename: output/base16-{{ scheme-slug }}.txt\n  supported-systems: [base16]\n",
+    )?;
+    write_to_file(
+        template_dir.join("templates").join("base16-test.mustache"),
+        "{{scheme-name}}\n",
+    )?;
+
+    write_to_file(&config_path, "")?;
+
+    // ---
+    // Act
+    // ---
+    let command = format!("build \"{}\"", template_dir.display());
+    let command_vec = build_command_vec(&command, &config_path, &data_path)?;
+    let (_stdout, stderr) = run_command(&command_vec)?;
+
+    // ------
+    // Assert
+    // ------
+    let output_path = template_dir
+        .join("output")
+        .join("base16-tinty-generated.txt");
+    assert!(
+        output_path.exists(),
+        "expected build output at {}; stderr: {stderr}",
+        output_path.display()
+    );
+    assert!(!stderr.contains("E111"), "unexpected E111 error: {stderr}");
+
+    Ok(())
+}


### PR DESCRIPTION
## What

`tinty build` failed with `E111: Invalid scheme file extension` whenever the
schemes repo contained anything that isn't a scheme file — e.g. `LICENSE` or
`README.md` at its root. Since that's the layout of the real schemes repo, a
stock `tinty build` broke.

## How

- Bumps `tinted-builder-rust` to `0.21.0`, which skips non-scheme files during
  scheme discovery (and stays strict about files inside the
  `base16`/`base24`/`tinted8` directories).
- Adopts its new `get_scheme_files_by_name` helper so scheme lookup shares one
  implementation instead of tinty keeping its own copy.

## Notes

- The discovery fix itself lives upstream in
  tinted-theming/tinted-builder-rust#37 (released as 0.21.0).
- Adds an integration test covering `build` against a schemes repo that carries
  non-scheme files at the root.
