### PR TITLE
feat(gallery): add browser-local favorites with cycle-ring guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Add favorites to the `tinty gallery` view. Click the heart on any scheme
+  card (or in its detail modal) to star it; favorites are remembered locally
+  in the browser with no server or account. A "Favorites" pill on the filter
+  bar narrows the grid to your starred schemes, and the favorites view offers
+  a ready-to-paste `config.toml` cycle-ring snippet plus a short guide for
+  rotating through them with `tinty cycle`.
+
 ## [0.34.0] - 2026-06-16
 
 ### Added

--- a/src/operations/gallery/gallery.css
+++ b/src/operations/gallery/gallery.css
@@ -48,6 +48,9 @@
   --accent-soft: color-mix(in oklab, var(--accent) 12%, transparent);
   --accent-softer: color-mix(in oklab, var(--accent) 7%, transparent);
   --accent-ring: color-mix(in oklab, var(--accent) 28%, transparent);
+  /* Favorites accent — a crimson "like" hue, kept separate from the brand
+     orange so favorites read as their own thing. */
+  --fav: #dc2645;
 
   --ring: 0 0 0 1px color-mix(in oklab, var(--ink-1) 7%, transparent);
   --shadow-sm: 0 1px 2px rgb(18 20 27 / 5%);
@@ -243,7 +246,7 @@ h1 {
 
 .controls {
   display: grid;
-  grid-template-columns: minmax(260px, 1fr) auto auto;
+  grid-template-columns: minmax(220px, 1fr) auto auto auto;
   gap: 10px;
   align-items: center;
   margin: 20px 0 4px;
@@ -369,6 +372,302 @@ h1 {
 .preview-button:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+/* Favorites — a browser-local "star" feature. Heart icons fill in when their
+   control is pressed; favorited cards also carry .is-favorite. */
+.icon-heart {
+  fill: none;
+  transition: fill 140ms ease;
+}
+
+[aria-pressed="true"] .icon-heart {
+  fill: currentColor;
+}
+
+/* Filter-bar pill that restricts the grid to favorites. Styled to sit beside
+   the .filter-group strips, with a count badge once there are favorites. */
+.favorites-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 40px;
+  padding: 4px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: color-mix(in oklab, var(--ink-1) 4%, transparent);
+  color: var(--ink-2);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 140ms ease, color 140ms ease, border-color 140ms ease;
+}
+
+.favorites-pill:hover {
+  color: var(--ink-1);
+  border-color: var(--border-strong);
+}
+
+.favorites-pill:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.favorites-pill[aria-pressed="true"] {
+  color: var(--fav);
+  border-color: color-mix(in oklab, var(--fav) 22%, var(--border));
+  background: color-mix(in oklab, var(--fav) 8%, transparent);
+}
+
+.favorites-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: var(--radius-full);
+  background: color-mix(in oklab, var(--fav) 20%, transparent);
+  color: var(--fav);
+  font-size: 11px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.favorites-count[hidden] {
+  display: none;
+}
+
+/* Per-card heart, floated over the preview opposite the system/appearance
+   pills. Revealed on hover/focus to keep the grid quiet; pinned visible once
+   favorited. Deliberately cheap to paint (no halo) — see the §12 note about
+   per-card compositing cost in the gallery design doc. */
+.favorite-toggle {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-full);
+  background: color-mix(in oklab, var(--preview-bg, var(--surface)) 62%, transparent);
+  color: var(--preview-fg, var(--ink-2));
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(.9);
+  transition: opacity 140ms ease, transform 140ms ease, color 140ms ease, background-color 140ms ease;
+}
+
+.card:hover .favorite-toggle,
+.card:focus-within .favorite-toggle,
+.favorite-toggle:focus-visible,
+.favorite-toggle[aria-pressed="true"] {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.favorite-toggle:hover {
+  background: color-mix(in oklab, var(--preview-bg, var(--surface)) 80%, transparent);
+}
+
+.favorite-toggle[aria-pressed="true"] {
+  color: var(--fav);
+}
+
+.favorite-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.favorite-toggle:active {
+  transform: scale(.86);
+}
+
+.favorite-toggle .icon-heart {
+  width: 17px;
+  height: 17px;
+  flex-basis: 17px;
+}
+
+/* Modal favorite button — labeled, always visible (the touch-friendly path to
+   favoriting, since the card heart only appears on hover). Themed with the
+   scheme's preview colors so it reads on the modal's scheme-colored header. */
+.favorite-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 12px 3px 9px;
+  border: 1px solid color-mix(in oklab, var(--preview-fg, var(--border)) 28%, transparent);
+  border-radius: var(--radius-full);
+  background: color-mix(in oklab, var(--preview-bg, var(--surface)) 70%, transparent);
+  color: var(--preview-fg, var(--ink-2));
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .02em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background-color 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.favorite-button:hover {
+  background: color-mix(in oklab, var(--preview-bg, var(--surface)) 55%, transparent);
+  border-color: color-mix(in oklab, var(--preview-fg, var(--border)) 45%, transparent);
+}
+
+.favorite-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.favorite-button:active {
+  transform: scale(.96);
+}
+
+.favorite-button[aria-pressed="true"] {
+  color: var(--fav);
+  border-color: color-mix(in oklab, var(--fav) 32%, transparent);
+  background: color-mix(in oklab, var(--fav) 12%, transparent);
+}
+
+.favorite-button .icon-heart {
+  width: 13px;
+  height: 13px;
+  flex-basis: 13px;
+}
+
+/* Cycle-ring callout — shown above the grid only in the Favorites view when at
+   least one scheme is favorited. Advertises `tinty cycle` with a ready-to-paste
+   config snippet and a short guide. */
+.favorites-ring {
+  margin: 14px 0 0;
+  padding: 16px 18px 18px;
+  background: color-mix(in oklab, var(--surface) 82%, transparent);
+  border: 1px solid color-mix(in oklab, var(--fav) 25%, var(--border));
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.favorites-ring[hidden] {
+  display: none;
+}
+
+.favorites-ring .section-label {
+  color: var(--fav);
+}
+
+.favorites-ring-intro {
+  margin-top: 8px;
+  max-width: 70ch;
+  color: var(--ink-3);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.favorites-ring-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 20px;
+  margin-top: 16px;
+}
+
+.inline-code {
+  padding: 1px 6px;
+  background: color-mix(in oklab, var(--ink-1) 7%, transparent);
+  border-radius: var(--radius-xs);
+  font: 0.92em var(--font-mono);
+  color: var(--ink-1);
+}
+
+.ring-snippet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.ring-snippet-label {
+  color: var(--ink-3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.ring-snippet-head .icon-button {
+  min-width: 30px;
+  min-height: 30px;
+}
+
+.ring-code {
+  margin: 0;
+  padding: 12px 14px;
+  max-height: 240px;
+  overflow: auto;
+  background: color-mix(in oklab, var(--ink-1) 4%, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.ring-code code {
+  font: 12.5px/1.6 var(--font-mono);
+  color: var(--ink-1);
+  white-space: pre;
+}
+
+/* When syntax-highlighted, the block adopts the GitHub base16 palette: its
+   background/foreground come from the scheme's --preview-* props (set in JS),
+   and the token spans reuse the shared .function/.string/.keyword rules. */
+.ring-code.is-themed {
+  background: var(--preview-bg);
+  border-color: color-mix(in oklab, var(--preview-fg) 16%, transparent);
+}
+
+.ring-code.is-themed code {
+  color: var(--preview-fg);
+}
+
+.ring-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ring-guide-step {
+  display: flex;
+  gap: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.ring-step-num {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-full);
+  background: color-mix(in oklab, var(--fav) 14%, transparent);
+  color: var(--fav);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.ring-command {
+  margin-top: 8px;
 }
 
 .gallery {
@@ -1103,6 +1402,7 @@ body.sheet-open .sheet-backdrop {
   font-weight: 500;
   transform: translate(-50%, 18px);
   opacity: 0;
+  pointer-events: none;
   transition: opacity 160ms ease, transform 220ms cubic-bezier(.2, .8, .2, 1);
 }
 
@@ -1196,6 +1496,15 @@ body.sheet-open .sheet-backdrop {
     justify-content: center;
   }
 
+  .favorites-pill {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .favorites-ring-body {
+    grid-template-columns: 1fr;
+  }
+
   .detail-sheet {
     top: auto;
     bottom: 0;
@@ -1238,6 +1547,7 @@ body.sheet-open .sheet-backdrop {
     --accent-soft: color-mix(in oklab, var(--accent) 18%, transparent);
     --accent-softer: color-mix(in oklab, var(--accent) 10%, transparent);
     --accent-ring: color-mix(in oklab, var(--accent) 35%, transparent);
+    --fav: #e5484d;
     --tooltip-bg: #f5f5f4;
     --tooltip-ink: #0f1115;
     --tooltip-border: #d6d4cd;
@@ -1330,6 +1640,7 @@ body.sheet-open .sheet-backdrop {
   --accent-soft: color-mix(in oklab, var(--accent) 12%, transparent);
   --accent-softer: color-mix(in oklab, var(--accent) 7%, transparent);
   --accent-ring: color-mix(in oklab, var(--accent) 28%, transparent);
+  --fav: #dc2645;
   --tooltip-bg: #0f1115;
   --tooltip-ink: #f5f5f4;
   --tooltip-border: #2a2f38;
@@ -1359,6 +1670,7 @@ body.sheet-open .sheet-backdrop {
   --accent-soft: color-mix(in oklab, var(--accent) 18%, transparent);
   --accent-softer: color-mix(in oklab, var(--accent) 10%, transparent);
   --accent-ring: color-mix(in oklab, var(--accent) 35%, transparent);
+  --fav: #e5484d;
   --tooltip-bg: #f5f5f4;
   --tooltip-ink: #0f1115;
   --tooltip-border: #d6d4cd;

--- a/src/operations/gallery/gallery.js
+++ b/src/operations/gallery/gallery.js
@@ -15,13 +15,24 @@ const state = {
   // value) when the gallery flips to palette.
   modalLanguage: "rust",
   variablesView: "palette",
+  // When true, only schemes the user has favorited (browser-local) are shown.
+  favoritesOnly: false,
 };
 let currentSheetId = null;
 let tooltipTimeoutId = null;
+let toastTimeoutId = null;
 let isFirstRender = true;
 const PAGE_THEME_STORAGE_KEY = "tinty-gallery-page-theme";
 const LANGUAGE_STORAGE_KEY = "tinty-gallery-preview-language";
 const MODAL_LANGUAGE_STORAGE_KEY = "tinty-gallery-modal-language";
+// Favorites live purely in the browser — no server, no account. The set of
+// favorited scheme ids is persisted as a JSON array under this key.
+const FAVORITES_STORAGE_KEY = "tinty-gallery-favorites";
+// One-shot flag so the "turn your favorites into a cycle ring" nudge is shown
+// once (when the user first has enough favorites to make a ring), not nagged.
+const RING_TIP_STORAGE_KEY = "tinty-gallery-ring-tip-seen";
+// Name used for the generated cycle ring in the config.toml snippet.
+const FAVORITES_RING_NAME = "favorites";
 
 const fallbackPalette = {
   base00: "#101418",
@@ -37,6 +48,186 @@ const fallbackPalette = {
 };
 
 SCHEMES.sort((a, b) => a.id.localeCompare(b.id));
+
+const KNOWN_SCHEME_IDS = new Set(SCHEMES.map((scheme) => scheme.id));
+
+// Read the persisted favorites, dropping anything malformed or pointing at a
+// scheme that no longer exists in this build. Insertion order is preserved so
+// the generated cycle ring keeps the order the user favorited things in.
+function loadFavorites() {
+  try {
+    const raw = window.localStorage.getItem(FAVORITES_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id) => typeof id === "string" && KNOWN_SCHEME_IDS.has(id));
+  } catch (_error) {
+    return [];
+  }
+}
+
+const favorites = new Set(loadFavorites());
+
+function saveFavorites() {
+  window.localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify([...favorites]));
+}
+
+function isFavorite(id) {
+  return favorites.has(id);
+}
+
+// Sync a favorite control (card heart, modal button) to a pressed/unpressed
+// state. Handles the optional text label used by the modal button.
+function updateFavoriteButton(button, on) {
+  if (!button) return;
+  button.setAttribute("aria-pressed", on ? "true" : "false");
+  button.setAttribute("aria-label", on ? "Remove from favorites" : "Add to favorites");
+  const label = button.querySelector(".favorite-label");
+  if (label) {
+    label.textContent = on ? "Favorited" : "Favorite";
+  }
+}
+
+function showToast(message, duration = 2600) {
+  const toast = document.getElementById("toast");
+  toast.textContent = message;
+  toast.hidden = false;
+  // Force a reflow so the entrance transition plays from the closed state.
+  void toast.offsetWidth;
+  toast.classList.add("open");
+  if (toastTimeoutId) {
+    window.clearTimeout(toastTimeoutId);
+  }
+  toastTimeoutId = window.setTimeout(() => {
+    toast.classList.remove("open");
+  }, duration);
+}
+
+// Tasteful disclosure of the cycle-ring feature: a plain confirmation most of
+// the time, and — exactly once, the first time the user has enough favorites
+// to form a ring — a one-line nudge toward the Favorites view where the full
+// config snippet and guide live.
+function announceFavorite(on) {
+  if (!on) {
+    showToast("Removed from favorites");
+    return;
+  }
+  const tipSeen = window.localStorage.getItem(RING_TIP_STORAGE_KEY) === "1";
+  if (!tipSeen && favorites.size >= 2) {
+    window.localStorage.setItem(RING_TIP_STORAGE_KEY, "1");
+    showToast("Saved ♥  Tip: cycle your favorites as a Tinty ring — open Favorites for the config", 5200);
+  } else {
+    showToast("Added to favorites ♥");
+  }
+}
+
+function toggleFavorite(id) {
+  const nowFavorite = !favorites.has(id);
+  if (nowFavorite) {
+    favorites.add(id);
+  } else {
+    favorites.delete(id);
+  }
+  saveFavorites();
+
+  const card = document.querySelector(`.card[data-scheme-id="${CSS.escape(id)}"]`);
+  if (card) {
+    updateFavoriteButton(card.querySelector(".favorite-toggle"), nowFavorite);
+    card.classList.toggle("is-favorite", nowFavorite);
+  }
+  if (currentSheetId === id) {
+    updateFavoriteButton(document.getElementById("sheet-favorite"), nowFavorite);
+  }
+
+  updateFavoritesCount();
+  announceFavorite(nowFavorite);
+
+  // In the Favorites view the visible set and the ring snippet both change as
+  // schemes come and go; re-render through the layout transition so the grid
+  // re-flows smoothly.
+  if (state.favoritesOnly) {
+    transitionLayout(() => {
+      renderFavoritesRing();
+      render();
+    });
+  } else {
+    renderFavoritesRing();
+  }
+}
+
+function updateFavoritesCount() {
+  const badge = document.getElementById("favorites-count");
+  const count = favorites.size;
+  badge.textContent = String(count);
+  badge.hidden = count === 0;
+}
+
+// Build the `[[rings]]` block for config.toml from the current favorites.
+// Scheme ids are slug-safe ([a-z0-9-]) so no escaping is needed, and one
+// scheme per line keeps a long ring readable when pasted into a config.
+function favoritesRingToml() {
+  const schemes = [...favorites].map((id) => `  "${id}",`).join("\n");
+  // Set the ring as the default cycle ring so a bare `tinty cycle` rotates
+  // through it. The top-level key must precede the [[rings]] table in TOML.
+  return `default-cycle-ring = "${FAVORITES_RING_NAME}"\n\n[[rings]]\nname = "${FAVORITES_RING_NAME}"\nschemes = [\n${schemes}\n]`;
+}
+
+function escapeHtml(text) {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Syntax-highlighted version of the TOML above. Reuses the gallery's role
+// classes (.function/.string/.keyword read the --preview-* custom properties)
+// so the block is colored by whatever scheme is applied to the code element.
+function favoritesRingHtml() {
+  const str = (value) => `<span class="string">"${escapeHtml(value)}"</span>`;
+  const key = (name) => `<span class="function">${name}</span>`;
+  const lines = [
+    `${key("default-cycle-ring")} = ${str(FAVORITES_RING_NAME)}`,
+    "",
+    `<span class="keyword">[[rings]]</span>`,
+    `${key("name")} = ${str(FAVORITES_RING_NAME)}`,
+    `${key("schemes")} = [`,
+    ...[...favorites].map((id) => `  ${str(id)},`),
+    "]",
+  ];
+  return lines.join("\n");
+}
+
+// Pick the GitHub base16 scheme that matches the page's light/dark appearance,
+// so the config snippet always reads like a real editor regardless of theme.
+function ringSyntaxScheme() {
+  const id = effectivePageTheme() === "dark" ? "base16-github-dark" : "base16-github";
+  return SCHEMES.find((scheme) => scheme.id === id) || null;
+}
+
+// The ring callout only appears in the Favorites view and only when there is
+// at least one favorite — discoverable when relevant, invisible otherwise.
+function renderFavoritesRing() {
+  const section = document.getElementById("favorites-ring");
+  const show = state.favoritesOnly && favorites.size > 0;
+  section.hidden = !show;
+  if (!show) return;
+
+  const codeEl = document.getElementById("favorites-ring-toml");
+  const pre = codeEl.closest(".ring-code");
+  const scheme = ringSyntaxScheme();
+  if (scheme) {
+    // Theme the block with the GitHub palette and highlight the TOML.
+    setPreviewColors(pre, scheme);
+    pre.classList.add("is-themed");
+    codeEl.innerHTML = favoritesRingHtml();
+  } else {
+    // Fall back to plain, page-themed text if GitHub schemes are absent.
+    pre.classList.remove("is-themed");
+    codeEl.textContent = favoritesRingToml();
+  }
+
+  // The copy buttons always carry plain text, never the highlighted markup.
+  document.getElementById("copy-ring").dataset.command = favoritesRingToml();
+  const cycleCommand = document.getElementById("ring-cycle-command").textContent;
+  document.getElementById("copy-ring-command").dataset.command = cycleCommand;
+}
 
 function getSnippet(lang) {
   const template = document.getElementById(`snippet-${lang}`);
@@ -208,6 +399,10 @@ function searchableText(scheme) {
 }
 
 function matchesFilters(scheme) {
+  if (state.favoritesOnly && !favorites.has(scheme.id)) {
+    return false;
+  }
+
   if (state.system !== "all" && String(scheme.system).toLowerCase() !== state.system) {
     return false;
   }
@@ -547,6 +742,7 @@ function applySheetState(scheme, updateHash) {
   setPreviewColors(sheet, scheme);
   renderModalPreview();
   document.getElementById("sheet-title").textContent = scheme.name;
+  updateFavoriteButton(document.getElementById("sheet-favorite"), favorites.has(scheme.id));
   document.querySelector("#sheet-system span").textContent = scheme.system;
   document.querySelector("#sheet-appearance span").textContent = appearance(scheme);
   document.getElementById("sheet-command").textContent = command;
@@ -685,6 +881,15 @@ function createCard(scheme) {
   card.querySelector(".scheme-appearance span").textContent = appearance(scheme);
   renderPreviewInto(card.querySelector(".code-preview"), scheme, state.language);
 
+  const favToggle = card.querySelector(".favorite-toggle");
+  const favorited = favorites.has(scheme.id);
+  card.classList.toggle("is-favorite", favorited);
+  updateFavoriteButton(favToggle, favorited);
+  favToggle.addEventListener("click", (event) => {
+    event.stopPropagation();
+    toggleFavorite(scheme.id);
+  });
+
   card.querySelector(".preview-button").addEventListener("click", () => {
     openSheet(scheme, true, card);
   });
@@ -734,6 +939,10 @@ function render() {
   }
 
   empty.hidden = visible.length !== 0;
+  empty.textContent =
+    state.favoritesOnly && favorites.size === 0
+      ? "No favorites yet — tap the ♥ on any scheme to save it."
+      : "No matching schemes.";
   count.textContent = `${visible.length} of ${SCHEMES.length} schemes`;
 
   isFirstRender = false;
@@ -760,6 +969,8 @@ function setPageTheme(theme) {
     .forEach((candidate) => candidate.classList.toggle("active", candidate.dataset.pageTheme === theme));
 
   render();
+  // Re-pick the GitHub light/dark variant for the ring snippet.
+  renderFavoritesRing();
 }
 
 function loadSavedPageTheme() {
@@ -810,18 +1021,39 @@ document.querySelectorAll("[data-variables-view]").forEach((button) => {
   });
 });
 
-document.getElementById("sheet-close").addEventListener("click", closeSheet);
-document.getElementById("sheet-backdrop").addEventListener("click", closeSheet);
-document.getElementById("copy-command").addEventListener("click", async (event) => {
-  const button = event.currentTarget;
+document.getElementById("favorites-filter").addEventListener("click", () => {
+  transitionLayout(() => {
+    state.favoritesOnly = !state.favoritesOnly;
+    document
+      .getElementById("favorites-filter")
+      .setAttribute("aria-pressed", state.favoritesOnly ? "true" : "false");
+    renderFavoritesRing();
+    render();
+  });
+});
 
-  try {
-    await navigator.clipboard.writeText(button.dataset.command);
-    showButtonTooltip(button, "Copied");
-  } catch (_error) {
-    showButtonTooltip(button, "Copy failed");
+document.getElementById("sheet-favorite").addEventListener("click", () => {
+  if (currentSheetId) {
+    toggleFavorite(currentSheetId);
   }
 });
+
+document.getElementById("sheet-close").addEventListener("click", closeSheet);
+document.getElementById("sheet-backdrop").addEventListener("click", closeSheet);
+
+function attachCopyButton(id) {
+  document.getElementById(id).addEventListener("click", async (event) => {
+    const button = event.currentTarget;
+    try {
+      await navigator.clipboard.writeText(button.dataset.command || "");
+      showButtonTooltip(button, "Copied");
+    } catch (_error) {
+      showButtonTooltip(button, "Copy failed");
+    }
+  });
+}
+
+["copy-command", "copy-ring", "copy-ring-command"].forEach(attachCopyButton);
 
 document.addEventListener("keydown", (event) => {
   if (event.key === "Escape") {
@@ -832,5 +1064,6 @@ document.addEventListener("keydown", (event) => {
 window.addEventListener("hashchange", syncSheetToHash);
 
 loadSavedLanguage();
+updateFavoritesCount();
 loadSavedPageTheme();
 syncSheetToHash();

--- a/src/operations/gallery/index.html
+++ b/src/operations/gallery/index.html
@@ -84,6 +84,60 @@
             Both
           </button>
         </div>
+        <button type="button" id="favorites-filter" class="favorites-pill" aria-pressed="false" aria-label="Show favorites only">
+          <svg class="icon icon-heart" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.49 4.04 3 5.5l7 7Z"></path></svg>
+          Favorites
+          <span id="favorites-count" class="favorites-count" hidden></span>
+        </button>
+      </section>
+
+      <section id="favorites-ring" class="favorites-ring" hidden aria-label="Cycle your favorites">
+        <div class="favorites-ring-head">
+          <div class="section-label">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-2.64-6.36"></path><path d="M21 3v6h-6"></path></svg>
+            Cycle your favorites
+          </div>
+          <p class="favorites-ring-intro">
+            Tinty can rotate through a saved ring of schemes. Drop this into your
+            <code class="inline-code">config.toml</code> to make your favorites the default
+            ring, then step through them with a single command.
+          </p>
+        </div>
+        <div class="favorites-ring-body">
+          <div class="ring-snippet">
+            <div class="ring-snippet-head">
+              <span class="ring-snippet-label">config.toml</span>
+              <button type="button" id="copy-ring" class="icon-button" aria-label="Copy ring config" data-tooltip="Copy config">
+                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="8" width="11" height="11" rx="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v1"></path></svg>
+              </button>
+            </div>
+            <pre class="ring-code"><code id="favorites-ring-toml"></code></pre>
+          </div>
+          <ol class="ring-guide">
+            <li class="ring-guide-step">
+              <span class="ring-step-num">1</span>
+              <div>Add this to your <code class="inline-code">config.toml</code> — it saves the ring and makes it your default.</div>
+            </li>
+            <li class="ring-guide-step">
+              <span class="ring-step-num">2</span>
+              <div>
+                Apply the next favorite — no ring flag needed:
+                <div class="command-row ring-command">
+                  <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2"></rect><path d="m8 9 3 3-3 3"></path><path d="M13 15h3"></path></svg>
+                  <code id="ring-cycle-command">tinty cycle</code>
+                  <button type="button" id="copy-ring-command" class="icon-button" aria-label="Copy cycle command" data-tooltip="Copy command">
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="8" width="11" height="11" rx="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v1"></path></svg>
+                  </button>
+                </div>
+                Bind it to a key in your shell to flip themes on demand.
+              </div>
+            </li>
+            <li class="ring-guide-step">
+              <span class="ring-step-num">3</span>
+              <div>Keep more than one ring? Run <code class="inline-code">tinty cycle --help</code> to cycle a specific one with <code class="inline-code">--ring &lt;name&gt;</code>.</div>
+            </li>
+          </ol>
+        </div>
       </section>
 
       <section id="gallery" class="gallery" aria-label="Scheme previews"></section>
@@ -110,6 +164,10 @@
                 <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 3v18"></path></svg>
                 <span></span>
               </span>
+              <button type="button" id="sheet-favorite" class="favorite-button" aria-pressed="false" aria-label="Add to favorites">
+                <svg class="icon icon-heart" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.49 4.04 3 5.5l7 7Z"></path></svg>
+                <span class="favorite-label">Favorite</span>
+              </button>
             </div>
           </div>
         </div>
@@ -165,6 +223,9 @@
 
   <template id="card-template">
     <article class="card">
+      <button type="button" class="favorite-toggle" aria-pressed="false" aria-label="Add to favorites">
+        <svg class="icon icon-heart" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.49 4.04 3 5.5l7 7Z"></path></svg>
+      </button>
       <button type="button" class="preview-button">
         <div class="card-header">
           <span class="scheme-system meta-pill">


### PR DESCRIPTION
Let users star schemes from the card or detail modal, persisted purely in `localStorage`. A "Favorites" pill on the filter bar narrows the grid to starred schemes and shows a live-updating `config.toml` cycle-ring snippet plus a short guide for rotating through them with `tinty cycle`.

- Heart toggle on each card (revealed on hover/focus, pinned when favorited) and a labeled button in the detail modal.
- Favorites use a dedicated crimson `--fav` accent, with a restrained "tinted" active treatment.
- The ring snippet sets `default-cycle-ring` so the headline command is a bare `tinty cycle`, and points to `tinty cycle --help` for named rings.
- A one-time toast nudges toward the cycle ring once enough favorites exist.

<img width="3900" height="3068" alt="CleanShot 2026-06-18 at 23 16 55@2x" src="https://github.com/user-attachments/assets/4eb15ce6-1dd5-41a3-825d-f53cb0e79d03" />
<img width="3900" height="3068" alt="CleanShot 2026-06-18 at 23 16 53@2x" src="https://github.com/user-attachments/assets/298a4fed-2681-4f66-8c27-60a66a3a96c7" />
