### PR TITLE
fix(config): reject reserved "schemes" item name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Reject a config `[[items]]` entry named `schemes`, which is reserved for the
+  built-in schemes repository. Previously such an item silently collided with
+  the built-in repo on disk and was reverted to the official schemes repo on
+  `tinty update`; it now fails fast with a clear error asking you to rename it.
+
 ## [0.34.1] - 2026-06-20
 
 ### Changed

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::constants::REPO_NAME;
+use crate::constants::{REPO_NAME, SCHEMES_REPO_NAME};
 use anyhow::{anyhow, Context, Result};
 use home::home_dir;
 use serde::Deserialize;
@@ -106,6 +106,10 @@ fn ensure_item_name_is_unique(items: &[ConfigItem]) -> Result<()> {
     let mut names = HashSet::new();
 
     for item in items {
+        if item.name == SCHEMES_REPO_NAME {
+            return Err(anyhow!("config.toml item.name \"{SCHEMES_REPO_NAME}\" is reserved for the built-in schemes repository and cannot be used for a custom item. Please rename this item."));
+        }
+
         if !names.insert(&item.name) {
             return Err(anyhow!("config.toml item.name should be unique values, but \"{}\" is used for more than 1 item.name. Please change this to a unique value.", item.name));
         }

--- a/tests/cli_install_subcommand_tests.rs
+++ b/tests/cli_install_subcommand_tests.rs
@@ -51,6 +51,40 @@ themes-dir = "some-dir"
 }
 
 #[test]
+fn test_cli_install_subcommand_reserved_schemes_config_item_name() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let (config_path, _data_path, command_vec, _temp_dir) = setup(
+        "test_cli_install_subcommand_reserved_schemes_config_item_name",
+        "install",
+        true,
+    )?;
+    let config_content = r#"[[items]]
+path = "https://github.com/tinted-theming/schemes"
+name = "schemes"
+themes-dir = "some-dir"
+"#;
+    let expected_output = "config.toml item.name \"schemes\" is reserved for the built-in schemes repository and cannot be used for a custom item. Please rename this item.";
+    write_to_file(&config_path, config_content)?;
+
+    // ---
+    // Act
+    // ---
+    let (_, stderr) = utils::run_command(&command_vec)?;
+
+    // ------
+    // Assert
+    // ------
+    ensure!(
+        stderr.contains(expected_output),
+        "stderr does not contain the expected output"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_cli_install_subcommand_invalid_config_item_path() -> Result<()> {
     // -------
     // Arrange


### PR DESCRIPTION
## Summary

A config `[[items]]` entry named `schemes` silently collided with the built-in schemes repository on disk. `tinty install` *appeared* to honor the custom item (it cloned first, and the built-in install step skipped because the directory already existed), but the unconditional built-in update step reset the repo back to `tinted-theming/schemes@spec-0.11` on every `tinty update`. The name was never reserved — `ensure_item_name_is_unique` only checked user items against each other — so this was a silent footgun rather than a supported override.

This reserves the name: a `[[items]]` entry named `schemes` is now rejected during config validation (which runs on every `Config::read`, so it covers `install`, `update`, `apply`, `list`, etc.) with a clear error asking the user to rename the item.