### PR TITLE
feat(update): add `allow-dirty-update` to update repos with local changes

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+# Configuration for `cargo audit` (see the `audit` job in
+# .github/workflows/lint.yml). Kept in sync with the `[advisories].ignore`
+# list in deny.toml.
+[advisories]
+ignore = [
+    # quick-xml DoS advisories. Fixed in quick-xml >= 0.41.0, but it is a
+    # transitive dependency pinned to ^0.38.3 by tinted-builder 0.16.0, so it
+    # cannot be bumped until a tinted-builder release updates it. Remove these
+    # once that lands.
+    "RUSTSEC-2026-0194", # quick-xml: quadratic run time on duplicate attribute names
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Add an `allow-dirty-update` config option that lets `tinty update` run against
+  a repository with uncommitted changes, for iterating on a scheme or template
+  repo locally. Non-overlapping local changes are carried forward; an update
+  that would overwrite uncommitted work (or an untracked file) is refused and
+  leaves the working tree untouched. Set it per `[[items]]` entry, or top-level
+  to set the default for all items and the built-in schemes repo.
+
 ## [0.34.1] - 2026-06-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   a repository with uncommitted changes, for iterating on a scheme or template
   repo locally. Non-overlapping local changes are carried forward; an update
   that would overwrite uncommitted work (or an untracked file) is refused and
-  leaves the working tree untouched. Set it per `[[items]]` entry, or top-level
-  to set the default for all items and the built-in schemes repo.
+  leaves the working tree untouched. Set it per `[[items]]` entry, or under the
+  `[schemes]` table for the built-in schemes repo.
 
 ## [0.34.1] - 2026-06-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ to your preferences and environment.
 | `shell`           | `string`           | Optional | Specifies the shell command used to execute hooks. | `"sh -c '{}'"` | `shell = "bash -c '{}'"` |
 | `default-scheme`  | `string`           | Optional | Defines the default theme scheme to be applied if no specific scheme is set. | None | `default-scheme = "base16-mocha"` |
 | `default-cycle-ring` | `string`           | Optional | The configured ring used by `tinty cycle` when `--ring` is not provided. | None | `default-cycle-ring = "default"` |
+| `allow-dirty-update` | `boolean`          | Optional | Default for each item's `allow-dirty-update`, and the setting that governs the built-in schemes repo. When `false`, `tinty update` skips repositories with uncommitted changes. See the per-item note below. | `false` | `allow-dirty-update = true` |
 | `[[rings]]`       | `array<rings>`     | Optional | Named scheme cycles used by `tinty cycle`. | - | See below |
 | `hooks`           | `array<string>`    | Optional | A list of strings which are executed after every `tinty apply` | None | `hooks = ["echo \"The current scheme is: $(tinty current)\""]` |
 | `[[items]]`       | `array<items>`     | Required | An array of `items` configurations. Each item represents a themeable component. Detailed structure provided in the next section. | - | - |
@@ -315,6 +316,25 @@ themes across different applications seamlessly.
 | `theme-file-extension` | `string` | Optional | Define a custom theme file extension that isn't `/\.*$/`. Tinty looks for themes named `base16-uwunicorn.*` (for example), but when the theme file isn't structured that way, this option can help specify the pattern. | - | `theme-file-extension = ".module.css"` |
 | `supported-systems`    | `array<"base16" or "base24" or "tinted8">` | Optional | Defines which theming systems ("base16" and or "base24") are supported by the item. | `["base16"]` | `supported-systems = ["base16", "base24"]` |
 | `write-to-file`        | `array<"target_filename", "optional_start_marker", "optional_end_marker">` | Optional | A feature where Tinty writes the theme content directly into an existing file. | None    | `write-to-file = ["~/.config/alacritty/config.toml", "# Tinty Start", "# Tinty End"]` |
+| `allow-dirty-update`   | `boolean` | Optional | Allow `tinty update` to run even when this item's local copy has uncommitted changes. Overrides the top-level `allow-dirty-update` default for this item. | top-level value (`false`) | `allow-dirty-update = true` |
+
+#### Note on `allow-dirty-update`
+
+By default `tinty update` skips any item whose local copy has uncommitted
+changes, so you never lose in-progress work. Setting `allow-dirty-update = true`
+lets the update proceed against a dirty working tree, which is handy when you
+are iterating on a scheme or template repository locally:
+
+- Local changes to files the update does **not** touch are carried forward
+  untouched, and the update succeeds.
+- If the update **would** overwrite your uncommitted changes (or an untracked
+  file that the incoming revision adds), it is refused and your working tree is
+  left exactly as it was. Tinty prints the conflicting files and how to unblock
+  the update (commit, stash, or remove them).
+
+The top-level `allow-dirty-update` key (see below) sets the default for every
+item and also governs the built-in schemes repository, which has no `[[items]]`
+entry of its own. A per-item `allow-dirty-update` overrides that default.
 
 #### Note on `supported-systems`
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ to your preferences and environment.
 | `shell`           | `string`           | Optional | Specifies the shell command used to execute hooks. | `"sh -c '{}'"` | `shell = "bash -c '{}'"` |
 | `default-scheme`  | `string`           | Optional | Defines the default theme scheme to be applied if no specific scheme is set. | None | `default-scheme = "base16-mocha"` |
 | `default-cycle-ring` | `string`           | Optional | The configured ring used by `tinty cycle` when `--ring` is not provided. | None | `default-cycle-ring = "default"` |
-| `allow-dirty-update` | `boolean`          | Optional | Default for each item's `allow-dirty-update`, and the setting that governs the built-in schemes repo. When `false`, `tinty update` skips repositories with uncommitted changes. See the per-item note below. | `false` | `allow-dirty-update = true` |
+| `[schemes]`       | `table`            | Optional | Settings for the built-in schemes repository. See the [`[schemes]` table](#schemes-table-configtoml-schema) below. | - | See below |
 | `[[rings]]`       | `array<rings>`     | Optional | Named scheme cycles used by `tinty cycle`. | - | See below |
 | `hooks`           | `array<string>`    | Optional | A list of strings which are executed after every `tinty apply` | None | `hooks = ["echo \"The current scheme is: $(tinty current)\""]` |
 | `[[items]]`       | `array<items>`     | Required | An array of `items` configurations. Each item represents a themeable component. Detailed structure provided in the next section. | - | - |
@@ -316,7 +316,7 @@ themes across different applications seamlessly.
 | `theme-file-extension` | `string` | Optional | Define a custom theme file extension that isn't `/\.*$/`. Tinty looks for themes named `base16-uwunicorn.*` (for example), but when the theme file isn't structured that way, this option can help specify the pattern. | - | `theme-file-extension = ".module.css"` |
 | `supported-systems`    | `array<"base16" or "base24" or "tinted8">` | Optional | Defines which theming systems ("base16" and or "base24") are supported by the item. | `["base16"]` | `supported-systems = ["base16", "base24"]` |
 | `write-to-file`        | `array<"target_filename", "optional_start_marker", "optional_end_marker">` | Optional | A feature where Tinty writes the theme content directly into an existing file. | None    | `write-to-file = ["~/.config/alacritty/config.toml", "# Tinty Start", "# Tinty End"]` |
-| `allow-dirty-update`   | `boolean` | Optional | Allow `tinty update` to run even when this item's local copy has uncommitted changes. Overrides the top-level `allow-dirty-update` default for this item. | top-level value (`false`) | `allow-dirty-update = true` |
+| `allow-dirty-update`   | `boolean` | Optional | Allow `tinty update` to run even when this item's local copy has uncommitted changes. | `false` | `allow-dirty-update = true` |
 
 #### Note on `allow-dirty-update`
 
@@ -332,9 +332,9 @@ are iterating on a scheme or template repository locally:
   left exactly as it was. Tinty prints the conflicting files and how to unblock
   the update (commit, stash, or remove them).
 
-The top-level `allow-dirty-update` key (see below) sets the default for every
-item and also governs the built-in schemes repository, which has no `[[items]]`
-entry of its own. A per-item `allow-dirty-update` overrides that default.
+This option is per-item. The built-in schemes repository has no `[[items]]`
+entry of its own, so its equivalent setting lives under the
+[`[schemes]` table](#schemes-table-configtoml-schema).
 
 #### Note on `supported-systems`
 
@@ -348,6 +348,20 @@ property.
 The `[[items]]` configuration allows defining multiple themeable
 components, each with its own set of configurations as described above.
 Here's how you might define multiple items in your `config.toml`:
+
+### Schemes table `config.toml` Schema
+
+The `[schemes]` table holds settings for the built-in schemes repository
+(the one Tinty manages itself, which has no `[[items]]` entry of its own).
+
+| Key                  | Type      | Required | Description                                                                 | Default | Example                     |
+|----------------------|-----------|----------|-----------------------------------------------------------------------------|---------|-----------------------------|
+| `allow-dirty-update` | `boolean` | Optional | Allow `tinty update` to update the schemes repo even when it has uncommitted changes. Behaves like an item's [`allow-dirty-update`](#note-on-allow-dirty-update). | `false` | `allow-dirty-update = true` |
+
+```toml
+[schemes]
+allow-dirty-update = true
+```
 
 ### Full Configuration Example
 

--- a/deny.toml
+++ b/deny.toml
@@ -58,4 +58,10 @@ unknown-git = "deny"
 [advisories]
 ignore = [
     "RUSTSEC-2024-0436", # paste crate is unmaintained
+    # quick-xml DoS advisories. Fixed in quick-xml >= 0.41.0, but it is a
+    # transitive dependency pinned to ^0.38.3 by tinted-builder 0.16.0, so it
+    # cannot be bumped until a tinted-builder release updates it. Remove these
+    # once that lands.
+    "RUSTSEC-2026-0194", # quick-xml: quadratic run time on duplicate attribute names
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation
 ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,13 @@ pub struct ConfigItem {
     pub revision: Option<String>,
     #[serde(rename = "write-to-file")]
     pub write_to_file: Option<Vec<String>>,
+    /// When `true`, `tinty update` is allowed to proceed even if this item's
+    /// local copy has uncommitted changes. Non-overlapping local edits are
+    /// carried forward; an update that would overwrite local changes is
+    /// refused without touching the working tree. When unset, the top-level
+    /// `allow-dirty-update` value is used as the default.
+    #[serde(default, rename = "allow-dirty-update")]
+    pub allow_dirty_update: Option<bool>,
 }
 
 impl fmt::Display for ConfigItem {
@@ -58,6 +65,9 @@ impl fmt::Display for ConfigItem {
         }
         if !revision.is_empty() {
             writeln!(f, "revision = \"{revision}\"")?;
+        }
+        if let Some(allow_dirty_update) = self.allow_dirty_update {
+            writeln!(f, "allow-dirty-update = {allow_dirty_update}")?;
         }
         writeln!(f, "supported-systems = [{system_text}]")?;
         write!(f, "themes-dir = \"{}\"", self.themes_dir)
@@ -100,6 +110,11 @@ pub struct Config {
     pub default_cycle_ring: Option<String>,
     pub items: Option<Vec<ConfigItem>>,
     pub hooks: Option<Vec<String>>,
+    /// Default for each item's `allow-dirty-update`, and the setting that
+    /// governs the built-in schemes repo (which has no `[[items]]` entry).
+    /// Defaults to `false`, preserving the strict skip-if-dirty behavior.
+    #[serde(default, rename = "allow-dirty-update")]
+    pub allow_dirty_update: bool,
 }
 
 fn ensure_item_name_is_unique(items: &[ConfigItem]) -> Result<()> {
@@ -161,6 +176,7 @@ impl Config {
             theme_file_extension: None,
             revision: None,
             write_to_file: None,
+            allow_dirty_update: None,
         };
 
         // Add default `item` if no items exist
@@ -260,6 +276,10 @@ impl fmt::Display for Config {
             writeln!(f, "preferred-schemes = [{preferred_schemes_text}]")?;
         }
 
+        if self.allow_dirty_update {
+            writeln!(f, "allow-dirty-update = true")?;
+        }
+
         if let Some(hooks) = &self.hooks {
             writeln!(f, "hooks = [")?;
             for hook in hooks {
@@ -281,5 +301,67 @@ impl fmt::Display for Config {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, ConfigItem};
+
+    fn item_with(allow_dirty_update: Option<bool>) -> ConfigItem {
+        ConfigItem {
+            name: "example".to_string(),
+            path: "https://example.com/repo".to_string(),
+            hook: None,
+            themes_dir: "themes".to_string(),
+            supported_systems: None,
+            theme_file_extension: None,
+            revision: None,
+            write_to_file: None,
+            allow_dirty_update,
+        }
+    }
+
+    #[test]
+    fn item_allow_dirty_update_parses_when_present() {
+        let toml = r#"
+name = "example"
+path = "https://example.com/repo"
+themes-dir = "themes"
+allow-dirty-update = true
+"#;
+        let item: ConfigItem = toml::from_str(toml).unwrap();
+        assert_eq!(item.allow_dirty_update, Some(true));
+    }
+
+    #[test]
+    fn item_allow_dirty_update_defaults_to_none_when_absent() {
+        let toml = r#"
+name = "example"
+path = "https://example.com/repo"
+themes-dir = "themes"
+"#;
+        let item: ConfigItem = toml::from_str(toml).unwrap();
+        assert_eq!(item.allow_dirty_update, None);
+    }
+
+    #[test]
+    fn top_level_allow_dirty_update_parses_and_defaults_to_false() {
+        let with: Config = toml::from_str("allow-dirty-update = true\n").unwrap();
+        assert!(with.allow_dirty_update);
+
+        let without: Config = toml::from_str("shell = \"sh -c '{}'\"\n").unwrap();
+        assert!(!without.allow_dirty_update);
+    }
+
+    #[test]
+    fn item_display_emits_allow_dirty_update_only_when_set() {
+        assert!(item_with(Some(true))
+            .to_string()
+            .contains("allow-dirty-update = true"));
+        assert!(item_with(Some(false))
+            .to_string()
+            .contains("allow-dirty-update = false"));
+        assert!(!item_with(None).to_string().contains("allow-dirty-update"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,10 +35,9 @@ pub struct ConfigItem {
     /// When `true`, `tinty update` is allowed to proceed even if this item's
     /// local copy has uncommitted changes. Non-overlapping local edits are
     /// carried forward; an update that would overwrite local changes is
-    /// refused without touching the working tree. When unset, the top-level
-    /// `allow-dirty-update` value is used as the default.
+    /// refused without touching the working tree. Defaults to `false`.
     #[serde(default, rename = "allow-dirty-update")]
-    pub allow_dirty_update: Option<bool>,
+    pub allow_dirty_update: bool,
 }
 
 impl fmt::Display for ConfigItem {
@@ -66,8 +65,8 @@ impl fmt::Display for ConfigItem {
         if !revision.is_empty() {
             writeln!(f, "revision = \"{revision}\"")?;
         }
-        if let Some(allow_dirty_update) = self.allow_dirty_update {
-            writeln!(f, "allow-dirty-update = {allow_dirty_update}")?;
+        if self.allow_dirty_update {
+            writeln!(f, "allow-dirty-update = true")?;
         }
         writeln!(f, "supported-systems = [{system_text}]")?;
         write!(f, "themes-dir = \"{}\"", self.themes_dir)
@@ -97,6 +96,18 @@ impl fmt::Display for ConfigRing {
     }
 }
 
+/// Settings for the built-in schemes repository, which has no `[[items]]`
+/// entry of its own. Grouped under a `[schemes]` table so more schemes-repo
+/// specific options can be added here in the future.
+#[derive(Deserialize, Debug, Default)]
+pub struct SchemesConfig {
+    /// When `true`, `tinty update` is allowed to proceed even if the schemes
+    /// repo has uncommitted changes. Behaves like an item's `allow-dirty-update`.
+    /// Defaults to `false`, preserving the strict skip-if-dirty behavior.
+    #[serde(default, rename = "allow-dirty-update")]
+    pub allow_dirty_update: bool,
+}
+
 /// Structure for configuration
 #[derive(Deserialize, Debug)]
 pub struct Config {
@@ -110,11 +121,8 @@ pub struct Config {
     pub default_cycle_ring: Option<String>,
     pub items: Option<Vec<ConfigItem>>,
     pub hooks: Option<Vec<String>>,
-    /// Default for each item's `allow-dirty-update`, and the setting that
-    /// governs the built-in schemes repo (which has no `[[items]]` entry).
-    /// Defaults to `false`, preserving the strict skip-if-dirty behavior.
-    #[serde(default, rename = "allow-dirty-update")]
-    pub allow_dirty_update: bool,
+    #[serde(default)]
+    pub schemes: SchemesConfig,
 }
 
 fn ensure_item_name_is_unique(items: &[ConfigItem]) -> Result<()> {
@@ -176,7 +184,7 @@ impl Config {
             theme_file_extension: None,
             revision: None,
             write_to_file: None,
-            allow_dirty_update: None,
+            allow_dirty_update: false,
         };
 
         // Add default `item` if no items exist
@@ -276,16 +284,19 @@ impl fmt::Display for Config {
             writeln!(f, "preferred-schemes = [{preferred_schemes_text}]")?;
         }
 
-        if self.allow_dirty_update {
-            writeln!(f, "allow-dirty-update = true")?;
-        }
-
         if let Some(hooks) = &self.hooks {
             writeln!(f, "hooks = [")?;
             for hook in hooks {
                 writeln!(f, "  \"{hook}\"")?;
             }
             writeln!(f, "]")?;
+        }
+
+        // Emitted before the `[[rings]]`/`[[items]]` array-of-tables so its
+        // keys are not mis-parsed as belonging to the last array entry.
+        if self.schemes.allow_dirty_update {
+            writeln!(f, "\n[schemes]")?;
+            writeln!(f, "allow-dirty-update = true")?;
         }
 
         if let Some(rings) = &self.rings {
@@ -308,7 +319,7 @@ impl fmt::Display for Config {
 mod tests {
     use super::{Config, ConfigItem};
 
-    fn item_with(allow_dirty_update: Option<bool>) -> ConfigItem {
+    fn item_with(allow_dirty_update: bool) -> ConfigItem {
         ConfigItem {
             name: "example".to_string(),
             path: "https://example.com/repo".to_string(),
@@ -331,37 +342,51 @@ themes-dir = "themes"
 allow-dirty-update = true
 "#;
         let item: ConfigItem = toml::from_str(toml).unwrap();
-        assert_eq!(item.allow_dirty_update, Some(true));
+        assert!(item.allow_dirty_update);
     }
 
     #[test]
-    fn item_allow_dirty_update_defaults_to_none_when_absent() {
+    fn item_allow_dirty_update_defaults_to_false_when_absent() {
         let toml = r#"
 name = "example"
 path = "https://example.com/repo"
 themes-dir = "themes"
 "#;
         let item: ConfigItem = toml::from_str(toml).unwrap();
-        assert_eq!(item.allow_dirty_update, None);
+        assert!(!item.allow_dirty_update);
     }
 
     #[test]
-    fn top_level_allow_dirty_update_parses_and_defaults_to_false() {
-        let with: Config = toml::from_str("allow-dirty-update = true\n").unwrap();
-        assert!(with.allow_dirty_update);
+    fn schemes_allow_dirty_update_parses_and_defaults_to_false() {
+        let with: Config = toml::from_str("[schemes]\nallow-dirty-update = true\n").unwrap();
+        assert!(with.schemes.allow_dirty_update);
 
+        // `[schemes]` table present but the key omitted.
+        let table_only: Config = toml::from_str("[schemes]\n").unwrap();
+        assert!(!table_only.schemes.allow_dirty_update);
+
+        // No `[schemes]` table at all.
         let without: Config = toml::from_str("shell = \"sh -c '{}'\"\n").unwrap();
-        assert!(!without.allow_dirty_update);
+        assert!(!without.schemes.allow_dirty_update);
     }
 
     #[test]
-    fn item_display_emits_allow_dirty_update_only_when_set() {
-        assert!(item_with(Some(true))
+    fn item_display_emits_allow_dirty_update_only_when_true() {
+        assert!(item_with(true)
             .to_string()
             .contains("allow-dirty-update = true"));
-        assert!(item_with(Some(false))
-            .to_string()
-            .contains("allow-dirty-update = false"));
-        assert!(!item_with(None).to_string().contains("allow-dirty-update"));
+        assert!(!item_with(false).to_string().contains("allow-dirty-update"));
+    }
+
+    #[test]
+    fn config_display_emits_schemes_table_only_when_set() {
+        let mut config: Config = toml::from_str("[schemes]\nallow-dirty-update = true\n").unwrap();
+        config.shell = Some("sh -c '{}'".to_string());
+        let rendered = config.to_string();
+        assert!(rendered.contains("[schemes]"));
+        assert!(rendered.contains("allow-dirty-update = true"));
+
+        let off: Config = toml::from_str("shell = \"sh -c '{}'\"\n").unwrap();
+        assert!(!off.to_string().contains("[schemes]"));
     }
 }

--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -49,15 +49,12 @@ fn update_item(
 
 /// Prints a human-facing explanation when an update was refused because it
 /// would have overwritten the user's uncommitted work. The working tree is
-/// left untouched, so we echo git's own message verbatim (in yellow) — it
-/// already names the offending files and how to proceed.
+/// left untouched, so we echo git's own message verbatim — it already names
+/// the offending files and how to proceed.
 fn print_conflict_message(item_name: &str, git_stderr: &str) {
-    const YELLOW: &str = "\x1b[33m";
-    const RESET: &str = "\x1b[0m";
-
     println!("{item_name}: could not update — your local changes are preserved:");
     for line in git_stderr.lines() {
-        println!("{YELLOW}{line}{RESET}");
+        println!("{line}");
     }
 }
 

--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -66,22 +66,21 @@ fn print_conflict_message(item_name: &str, git_stderr: &str) {
 /// Updates the provided repositories in config file by doing a git pull
 pub fn update(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<()> {
     let config = Config::read(config_path)?;
-    // The top-level value is the default for every item and also governs the
-    // built-in schemes repo, which has no `[[items]]` entry of its own.
-    let global_allow_dirty = config.allow_dirty_update;
+    // The built-in schemes repo has no `[[items]]` entry, so its leniency is
+    // configured separately under `[schemes]`.
+    let schemes_allow_dirty = config.schemes.allow_dirty_update;
     let items = config.items.unwrap_or_default();
     let hooks_path = data_path.join(REPO_DIR);
 
     for item in items {
         let item_path = hooks_path.join(&item.name);
-        let allow_dirty = item.allow_dirty_update.unwrap_or(global_allow_dirty);
 
         update_item(
             item.name.as_str(),
             item.path.as_str(),
             &item_path,
             item.revision.as_deref(),
-            allow_dirty,
+            item.allow_dirty_update,
             is_quiet,
         )?;
     }
@@ -93,7 +92,7 @@ pub fn update(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<()
         SCHEMES_REPO_URL,
         &schemes_repo_path,
         Some(SCHEMES_REPO_REVISION),
-        global_allow_dirty,
+        schemes_allow_dirty,
         is_quiet,
     )?;
 

--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -1,5 +1,5 @@
 use crate::constants::{REPO_DIR, SCHEMES_REPO_NAME, SCHEMES_REPO_REVISION, SCHEMES_REPO_URL};
-use crate::repo;
+use crate::repo::{self, UpdateStatus};
 use crate::{config::Config, constants::REPO_NAME};
 use anyhow::{Context, Result};
 use std::path::Path;
@@ -9,19 +9,33 @@ fn update_item(
     item_url: &str,
     item_path: &Path,
     revision: Option<&str>,
+    allow_dirty: bool,
     is_quiet: bool,
 ) -> Result<()> {
     if item_path.is_dir() {
+        let rev = revision.unwrap_or("main");
         let is_clean = repo::is_clean(item_path)?;
 
         if is_clean {
-            let rev = revision.unwrap_or("main");
-
-            repo::update(item_path, item_url, revision)
+            repo::update(item_path, item_url, revision, false)
                 .with_context(|| format!("Error updating {item_name} to {item_url}@{rev}"))?;
 
             if !is_quiet {
                 println!("{item_name} up to date");
+            }
+        } else if allow_dirty {
+            let status = repo::update(item_path, item_url, revision, true)
+                .with_context(|| format!("Error updating {item_name} to {item_url}@{rev}"))?;
+
+            if !is_quiet {
+                match status {
+                    UpdateStatus::Updated => {
+                        println!("{item_name} up to date (local changes preserved)");
+                    }
+                    UpdateStatus::ConflictPreserved { stderr } => {
+                        print_conflict_message(item_name, &stderr);
+                    }
+                }
             }
         } else if !is_quiet {
             println!("{item_name} contains uncommitted changes, please commit or remove and then run `{REPO_NAME} update` again.");
@@ -33,22 +47,41 @@ fn update_item(
     Ok(())
 }
 
+/// Prints a human-facing explanation when an update was refused because it
+/// would have overwritten the user's uncommitted work. The working tree is
+/// left untouched, so we echo git's own message verbatim (in yellow) — it
+/// already names the offending files and how to proceed.
+fn print_conflict_message(item_name: &str, git_stderr: &str) {
+    const YELLOW: &str = "\x1b[33m";
+    const RESET: &str = "\x1b[0m";
+
+    println!("{item_name}: could not update — your local changes are preserved:");
+    for line in git_stderr.lines() {
+        println!("{YELLOW}{line}{RESET}");
+    }
+}
+
 /// Updates local files
 ///
 /// Updates the provided repositories in config file by doing a git pull
 pub fn update(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<()> {
     let config = Config::read(config_path)?;
+    // The top-level value is the default for every item and also governs the
+    // built-in schemes repo, which has no `[[items]]` entry of its own.
+    let global_allow_dirty = config.allow_dirty_update;
     let items = config.items.unwrap_or_default();
     let hooks_path = data_path.join(REPO_DIR);
 
     for item in items {
         let item_path = hooks_path.join(&item.name);
+        let allow_dirty = item.allow_dirty_update.unwrap_or(global_allow_dirty);
 
         update_item(
             item.name.as_str(),
             item.path.as_str(),
             &item_path,
             item.revision.as_deref(),
+            allow_dirty,
             is_quiet,
         )?;
     }
@@ -60,6 +93,7 @@ pub fn update(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<()
         SCHEMES_REPO_URL,
         &schemes_repo_path,
         Some(SCHEMES_REPO_REVISION),
+        global_allow_dirty,
         is_quiet,
     )?;
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3,6 +3,18 @@ use std::path::Path;
 
 pub mod git_shell;
 
+/// Outcome of an `update` that was allowed to run against a dirty working tree.
+#[derive(Debug, PartialEq, Eq)]
+pub enum UpdateStatus {
+    /// The repository was brought to the configured revision. Any
+    /// non-overlapping local changes were carried forward untouched.
+    Updated,
+    /// The update was refused because it would have overwritten local work.
+    /// The working tree was left exactly as it was; `stderr` is git's own
+    /// explanation, which names the offending files and how to proceed.
+    ConflictPreserved { stderr: String },
+}
+
 /// High-level repository operations tinty performs against a `[[items]]` entry:
 /// fetching it onto disk for the first time (`install`), bringing it up to a
 /// configured revision (`update`), and checking whether the local copy has
@@ -14,7 +26,18 @@ pub mod git_shell;
 /// which implementation runs.
 pub trait RepositoryBackend {
     fn install(&self, url: &str, target: &Path, revision: Option<&str>) -> Result<()>;
-    fn update(&self, target: &Path, url: &str, revision: Option<&str>) -> Result<()>;
+    /// Bring the local copy at `target` to `revision`. When `allow_dirty` is
+    /// `false` the caller guarantees a clean working tree. When `true` the
+    /// update may run against uncommitted changes: non-overlapping edits are
+    /// carried forward and a would-be-overwrite is reported via
+    /// [`UpdateStatus::ConflictPreserved`] rather than an error.
+    fn update(
+        &self,
+        target: &Path,
+        url: &str,
+        revision: Option<&str>,
+        allow_dirty: bool,
+    ) -> Result<UpdateStatus>;
     fn is_clean(&self, target: &Path) -> Result<bool>;
 }
 
@@ -31,8 +54,13 @@ pub fn install(url: &str, target: &Path, revision: Option<&str>) -> Result<()> {
     backend().install(url, target, revision)
 }
 
-pub fn update(target: &Path, url: &str, revision: Option<&str>) -> Result<()> {
-    backend().update(target, url, revision)
+pub fn update(
+    target: &Path,
+    url: &str,
+    revision: Option<&str>,
+    allow_dirty: bool,
+) -> Result<UpdateStatus> {
+    backend().update(target, url, revision, allow_dirty)
 }
 
 pub fn is_clean(target: &Path) -> Result<bool> {

--- a/src/repo/git_shell.rs
+++ b/src/repo/git_shell.rs
@@ -4,6 +4,7 @@ use crate::repo::{RepositoryBackend, UpdateStatus};
 use anyhow::{anyhow, Context, Error, Result};
 use rand::Rng;
 use regex::bytes::Regex;
+use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -412,13 +413,13 @@ fn git_to_revision(
     // that is an expected, recoverable outcome and the working tree is left
     // untouched. Any other non-zero exit is a genuine error.
     //
-    // Note the ordering: we run `checkout` first and probe with `read-tree`
-    // only afterwards, rather than using `read-tree` as a pre-flight gate. The
-    // probe could equally well run first, but `checkout` is what produces the
-    // human-facing message we want to show the user — and it must run in their
-    // locale to do so. `read-tree` is used purely as a yes/no oracle, never for
-    // its output. Checkout's atomicity makes this safe: on a conflict it changes
-    // nothing, so there is no half-applied state to undo before we probe.
+    // Note the ordering: we run `checkout` first and classify only afterwards,
+    // rather than gating on the probe. The probe could equally well run first,
+    // but `checkout` is what produces the human-facing message we want to show
+    // the user — and it must run in their locale to do so. The probe is used
+    // purely as a yes/no oracle, never for its output. Checkout's atomicity
+    // makes this safe: on a conflict it changes nothing, so there is no
+    // half-applied state to reason about before we classify.
     if allow_dirty && checkout_blocked_by_local_changes(repo_path, &resolved.sha)? {
         return Ok(UpdateStatus::ConflictPreserved { stderr });
     }
@@ -430,26 +431,53 @@ fn git_to_revision(
 }
 
 /// Locale-independent classification of a failed checkout: returns `true` when
-/// switching to `sha` would be refused because it would overwrite uncommitted
-/// changes or untracked files. Uses `git read-tree`'s dry-run (`-n`), which
-/// reports this through its exit code alone — no translatable text — and
-/// modifies neither the index nor the working tree.
+/// switching to `sha` would overwrite uncommitted or untracked work. Computed
+/// entirely from plumbing whose output is NUL-separated pathnames (never
+/// translatable text): the paths that differ between `HEAD` and `sha` (what the
+/// checkout would write) intersected with the paths that hold local content a
+/// checkout could clobber (tracked files differing from `HEAD`, whether staged
+/// or unstaged, plus untracked files).
+///
+/// `git read-tree`'s dry-run was tempting here but is not faithful: it checks
+/// the working tree against the index, so a purely *staged* overlapping change
+/// reads as "up to date" and would be misclassified as a hard error.
 fn checkout_blocked_by_local_changes(repo_path: &Path, sha: &str) -> Result<bool> {
-    let status = safe_command(
-        format!("git read-tree -n -m -u \"{sha}\"").as_str(),
+    // Paths the checkout would write (differ between HEAD and the target tree).
+    let changed = git_nul_paths(
         repo_path,
-    )?
-    .stdout(Stdio::null())
-    .stderr(Stdio::null())
-    .status()
-    .with_context(|| {
-        format!(
-            "Failed to check working tree safety in {}",
-            repo_path.display()
-        )
-    })?;
+        &format!("git diff-tree -r -z --name-only --no-commit-id HEAD \"{sha}\""),
+    )?;
+    if changed.is_empty() {
+        return Ok(false);
+    }
 
-    Ok(!status.success())
+    // Paths holding local content a checkout could clobber.
+    let mut dirty: HashSet<String> =
+        git_nul_paths(repo_path, "git diff-index -z --name-only HEAD")?
+            .into_iter()
+            .collect();
+    dirty.extend(git_nul_paths(
+        repo_path,
+        "git ls-files -z --others --exclude-standard",
+    )?);
+
+    Ok(changed.iter().any(|path| dirty.contains(path.as_str())))
+}
+
+/// Runs a git command whose stdout is NUL-separated pathnames (`-z
+/// --name-only` and friends) and returns them. This output form is a stable,
+/// locale-independent plumbing format.
+fn git_nul_paths(repo_path: &Path, command: &str) -> Result<Vec<String>> {
+    let output = safe_command(command, repo_path)?
+        .stderr(Stdio::null())
+        .output()
+        .with_context(|| format!("Failed to run `{command}` in {}", repo_path.display()))?;
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .split('\0')
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+        .collect())
 }
 
 fn git_is_working_dir_clean(target_dir: &Path) -> Result<bool> {

--- a/src/repo/git_shell.rs
+++ b/src/repo/git_shell.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_name_repetitions)]
 
-use crate::repo::RepositoryBackend;
+use crate::repo::{RepositoryBackend, UpdateStatus};
 use anyhow::{anyhow, Context, Error, Result};
 use rand::Rng;
 use regex::bytes::Regex;
@@ -17,8 +17,14 @@ impl RepositoryBackend for GitShellBackend {
         git_clone(url, target, revision)
     }
 
-    fn update(&self, target: &Path, url: &str, revision: Option<&str>) -> Result<()> {
-        git_update(target, url, revision)
+    fn update(
+        &self,
+        target: &Path,
+        url: &str,
+        revision: Option<&str>,
+        allow_dirty: bool,
+    ) -> Result<UpdateStatus> {
+        git_update(target, url, revision, allow_dirty)
     }
 
     fn is_clean(&self, target: &Path) -> Result<bool> {
@@ -52,7 +58,9 @@ fn git_clone(repo_url: &str, target_dir: &Path, revision: Option<&str>) -> Resul
         .with_context(|| format!("Failed to clone repository from {repo_url}"))?;
 
     if let Some(revision_str) = revision {
-        let result = git_to_revision(target_dir, "origin", revision_str);
+        // A freshly cloned tree is clean, so a conflict can never arise here;
+        // `allow_dirty` is irrelevant and the returned status is ignored.
+        let result = git_to_revision(target_dir, "origin", revision_str, false);
         if let Err(e) = result {
             // Cleanup! If we cannot checkout the revision, remove the directory.
             fs::remove_dir_all(target_dir)
@@ -64,7 +72,12 @@ fn git_clone(repo_url: &str, target_dir: &Path, revision: Option<&str>) -> Resul
     Ok(())
 }
 
-fn git_update(repo_path: &Path, repo_url: &str, revision: Option<&str>) -> Result<()> {
+fn git_update(
+    repo_path: &Path,
+    repo_url: &str,
+    revision: Option<&str>,
+    allow_dirty: bool,
+) -> Result<UpdateStatus> {
     if !repo_path.is_dir() {
         return Err(anyhow!(
             "Error with updating. {} is not a directory",
@@ -103,25 +116,28 @@ fn git_update(repo_path: &Path, repo_url: &str, revision: Option<&str>) -> Resul
     })?;
 
     let revision_str = revision.unwrap_or("main");
-    let res = git_to_revision(repo_path, &tmp_remote_name, revision_str);
+    let res = git_to_revision(repo_path, &tmp_remote_name, revision_str, allow_dirty);
 
-    if let Err(e) = res {
-        // Failed to switch to the desired revision. Cleanup!
-        safe_command(
-            format!("git remote rm \"{tmp_remote_name}\"").as_str(),
-            repo_path,
-        )?
-        .stdout(Stdio::null())
-        .status()
-        .with_context(|| {
-            format!(
-                "Failed to remove temporary remote {} in {}",
-                tmp_remote_name,
-                repo_path.display()
-            )
-        })?;
-        return Err(e);
-    }
+    let status = match res {
+        Ok(status) => status,
+        Err(e) => {
+            // Failed to switch to the desired revision. Cleanup!
+            safe_command(
+                format!("git remote rm \"{tmp_remote_name}\"").as_str(),
+                repo_path,
+            )?
+            .stdout(Stdio::null())
+            .status()
+            .with_context(|| {
+                format!(
+                    "Failed to remove temporary remote {} in {}",
+                    tmp_remote_name,
+                    repo_path.display()
+                )
+            })?;
+            return Err(e);
+        }
+    };
 
     safe_command(
         format!("git remote set-url origin \"{repo_url}\"").as_str(),
@@ -148,7 +164,7 @@ fn git_update(repo_path: &Path, repo_url: &str, revision: Option<&str>) -> Resul
         )
     })?;
 
-    Ok(())
+    Ok(status)
 }
 
 fn random_remote_name() -> String {
@@ -337,7 +353,12 @@ fn safe_command(command_str: &str, cwd: &Path) -> Result<Command, Error> {
     Ok(command)
 }
 
-fn git_to_revision(repo_path: &Path, remote_name: &str, revision: &str) -> Result<()> {
+fn git_to_revision(
+    repo_path: &Path,
+    remote_name: &str,
+    revision: &str,
+    allow_dirty: bool,
+) -> Result<UpdateStatus> {
     // Download the object from the remote
     safe_command(
         format!("git fetch --quiet \"{remote_name}\" \"{revision}\"").as_str(),
@@ -354,52 +375,81 @@ fn git_to_revision(repo_path: &Path, remote_name: &str, revision: &str) -> Resul
     // Normalize the revision into the SHA.
     let resolved = git_resolve_revision(repo_path, remote_name, revision)?;
 
-    match resolved.kind {
-        RevisionType::Branch => {
-            // Checkout the branch by name to keep HEAD attached, avoiding detached HEAD.
-            // Use -B to create or reset the local branch to the fetched SHA.
-            safe_command(
-                format!(
-                    "git checkout --quiet -B \"{revision}\" \"{}\"",
-                    resolved.sha
-                )
-                .as_str(),
-                repo_path,
-            )?
-            .stdout(Stdio::null())
-            .current_dir(repo_path)
-            .status()
-            .with_context(|| {
-                format!(
-                    "Failed to checkout branch {revision} in {}",
-                    repo_path.display()
-                )
-            })?;
-        }
-        RevisionType::Tag | RevisionType::Sha => {
-            // Tags and specific SHAs are expected to result in detached HEAD.
-            safe_command(
-                format!(
-                    "git -c advice.detachedHead=false checkout --quiet \"{}\"",
-                    resolved.sha
-                )
-                .as_str(),
-                repo_path,
-            )?
-            .stdout(Stdio::null())
-            .current_dir(repo_path)
-            .status()
-            .with_context(|| {
-                format!(
-                    "Failed to checkout {} in {}",
-                    resolved.sha,
-                    repo_path.display()
-                )
-            })?;
-        }
+    // Build the checkout. Branches are checked out by name (with `-B`) to keep
+    // HEAD attached; tags and specific SHAs are expected to detach HEAD.
+    let checkout_command = match resolved.kind {
+        RevisionType::Branch => format!(
+            "git checkout --quiet -B \"{revision}\" \"{}\"",
+            resolved.sha
+        ),
+        RevisionType::Tag | RevisionType::Sha => format!(
+            "git -c advice.detachedHead=false checkout --quiet \"{}\"",
+            resolved.sha
+        ),
+    };
+
+    // `git checkout` is atomic with respect to local changes: if the checkout
+    // would overwrite uncommitted work it aborts without modifying anything,
+    // and if it touches only untouched files it carries local edits forward.
+    // We capture its output so a would-be-overwrite can be surfaced cleanly
+    // instead of being treated as a hard error.
+    let output = safe_command(checkout_command.as_str(), repo_path)?
+        .stdout(Stdio::null())
+        .output()
+        .with_context(|| format!("Failed to checkout {revision} in {}", repo_path.display()))?;
+
+    if output.status.success() {
+        return Ok(UpdateStatus::Updated);
     }
 
-    Ok(())
+    // Preserve git's own (possibly localized) message so we can show it to the
+    // user verbatim.
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+    // When the caller permits a dirty working tree, classify the failure with a
+    // locale-independent plumbing probe instead of parsing the message text: if
+    // switching to this revision would overwrite uncommitted or untracked work,
+    // that is an expected, recoverable outcome and the working tree is left
+    // untouched. Any other non-zero exit is a genuine error.
+    //
+    // Note the ordering: we run `checkout` first and probe with `read-tree`
+    // only afterwards, rather than using `read-tree` as a pre-flight gate. The
+    // probe could equally well run first, but `checkout` is what produces the
+    // human-facing message we want to show the user — and it must run in their
+    // locale to do so. `read-tree` is used purely as a yes/no oracle, never for
+    // its output. Checkout's atomicity makes this safe: on a conflict it changes
+    // nothing, so there is no half-applied state to undo before we probe.
+    if allow_dirty && checkout_blocked_by_local_changes(repo_path, &resolved.sha)? {
+        return Ok(UpdateStatus::ConflictPreserved { stderr });
+    }
+
+    Err(anyhow!(
+        "Failed to checkout {revision} in {}:\n{stderr}",
+        repo_path.display(),
+    ))
+}
+
+/// Locale-independent classification of a failed checkout: returns `true` when
+/// switching to `sha` would be refused because it would overwrite uncommitted
+/// changes or untracked files. Uses `git read-tree`'s dry-run (`-n`), which
+/// reports this through its exit code alone — no translatable text — and
+/// modifies neither the index nor the working tree.
+fn checkout_blocked_by_local_changes(repo_path: &Path, sha: &str) -> Result<bool> {
+    let status = safe_command(
+        format!("git read-tree -n -m -u \"{sha}\"").as_str(),
+        repo_path,
+    )?
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .status()
+    .with_context(|| {
+        format!(
+            "Failed to check working tree safety in {}",
+            repo_path.display()
+        )
+    })?;
+
+    Ok(!status.success())
 }
 
 fn git_is_working_dir_clean(target_dir: &Path) -> Result<bool> {

--- a/tests/cli_update_allow_dirty_tests.rs
+++ b/tests/cli_update_allow_dirty_tests.rs
@@ -196,6 +196,72 @@ fn update_refuses_when_incoming_file_collides_with_untracked() -> Result<()> {
 }
 
 #[test]
+fn update_refuses_and_preserves_staged_work_on_conflict() -> Result<()> {
+    let f = fixture("allow_dirty_staged_conflict")?;
+
+    // Stage an edit to theme-a; upstream changes the same file.
+    fs::write(f.clone.join("theme-a.txt"), "my staged edit\n")?;
+    git(&f.clone, &["add", "theme-a.txt"])?;
+    remote_commit(&f.remote, "theme-a.txt", "upstream edit\n", "advance a")?;
+    let before = head(&f.clone)?;
+
+    write_to_file(&f.config_path, &item_config(&f.remote, Some(true)))?;
+    let (stdout, _) = run_update(&f.command_vec)?;
+
+    ensure!(
+        stdout.contains(&format!("{ITEM_NAME}: could not update")),
+        "A staged conflict must be reported as a preserved conflict, not a hard error.\nGot: {stdout}"
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-a.txt"))? == "my staged edit\n",
+        "The staged content must be left untouched."
+    );
+    // The change must remain staged, not silently unstaged.
+    ensure!(
+        git(&f.clone, &["diff", "--cached", "--name-only"])?.contains("theme-a.txt"),
+        "The change must still be staged after a refused update."
+    );
+    ensure!(
+        head(&f.clone)? == before,
+        "HEAD must not move when the update is refused."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn update_carries_staged_changes_forward_without_conflict() -> Result<()> {
+    let f = fixture("allow_dirty_staged_carry_forward")?;
+
+    // Stage an edit to theme-a; upstream only advances theme-b.
+    fs::write(f.clone.join("theme-a.txt"), "my staged edit\n")?;
+    git(&f.clone, &["add", "theme-a.txt"])?;
+    remote_commit(&f.remote, "theme-b.txt", "b2\n", "advance b")?;
+
+    write_to_file(&f.config_path, &item_config(&f.remote, Some(true)))?;
+    let (stdout, _) = run_update(&f.command_vec)?;
+
+    ensure!(
+        stdout.contains(&format!("{ITEM_NAME} up to date (local changes preserved)")),
+        "Expected a preserved-changes success message.\nGot: {stdout}"
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-a.txt"))? == "my staged edit\n",
+        "The staged edit must be carried forward untouched."
+    );
+    ensure!(
+        git(&f.clone, &["diff", "--cached", "--name-only"])?.contains("theme-a.txt"),
+        "The change must remain staged after a carry-forward update."
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-b.txt"))? == "b2\n",
+        "Upstream change to theme-b should have been applied."
+    );
+
+    Ok(())
+}
+
+#[test]
 fn update_is_blocked_when_flag_is_absent() -> Result<()> {
     let f = fixture("allow_dirty_blocked_default")?;
 

--- a/tests/cli_update_allow_dirty_tests.rs
+++ b/tests/cli_update_allow_dirty_tests.rs
@@ -1,0 +1,281 @@
+//! Integration tests for `allow-dirty-update`.
+//!
+//! These exercise `tinty update` against an item whose local copy has
+//! uncommitted changes. Unlike the other update tests, they use a throwaway
+//! **local** git repository as the remote, so they are fully deterministic and
+//! require no network access: we control exactly which files the "upstream"
+//! revision changes and can assert that the user's work is preserved.
+
+mod utils;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{ensure, Context, Result};
+use tempfile::TempDir;
+use utils::{run_command, run_command_with_env, setup, write_to_file};
+
+const ITEM_NAME: &str = "localtheme";
+
+/// Runs `tinty update` in the ambient locale. Conflict detection must not
+/// depend on the locale, so the tests deliberately do not force one (see also
+/// `conflict_is_detected_regardless_of_git_locale`).
+fn run_update(command_vec: &[String]) -> Result<(String, String)> {
+    run_command(command_vec)
+}
+
+/// A throwaway remote repo plus an installed clone of it under the tinty data
+/// directory, ready for a `tinty update` invocation.
+struct Fixture {
+    remote: PathBuf,
+    clone: PathBuf,
+    config_path: PathBuf,
+    command_vec: Vec<String>,
+    _temp: TempDir,
+}
+
+fn git(dir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .with_context(|| format!("failed to run git {args:?} in {}", dir.display()))?;
+    ensure!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn head(dir: &Path) -> Result<String> {
+    Ok(git(dir, &["rev-parse", "HEAD"])?.trim().to_string())
+}
+
+/// Creates a remote repo (with `theme-a.txt`/`theme-b.txt` on `main`) and
+/// clones it into the tinty data dir to simulate an installed item.
+fn fixture(name: &str) -> Result<Fixture> {
+    let (config_path, data_path, command_vec, temp) = setup(name, "update", false)?;
+
+    let remote = temp.path().join("remote");
+    fs::create_dir_all(&remote)?;
+    git(&remote, &["init", "-q", "-b", "main"])?;
+    git(&remote, &["config", "user.email", "tinty@test.local"])?;
+    git(&remote, &["config", "user.name", "tinty test"])?;
+    fs::write(remote.join("theme-a.txt"), "a1\n")?;
+    fs::write(remote.join("theme-b.txt"), "b1\n")?;
+    git(&remote, &["add", "-A"])?;
+    git(&remote, &["commit", "-q", "-m", "init"])?;
+
+    let clone = data_path.join("repos").join(ITEM_NAME);
+    fs::create_dir_all(clone.parent().unwrap())?;
+    let status = Command::new("git")
+        .args([
+            "clone",
+            "-q",
+            remote.to_str().unwrap(),
+            clone.to_str().unwrap(),
+        ])
+        .status()?;
+    ensure!(status.success(), "failed to clone local remote");
+
+    Ok(Fixture {
+        remote,
+        clone,
+        config_path,
+        command_vec,
+        _temp: temp,
+    })
+}
+
+/// `[[items]]` config for the fixture, optionally setting the per-item flag.
+fn item_config(remote: &Path, item_allow: Option<bool>) -> String {
+    let mut config = format!(
+        "[[items]]\npath = \"{}\"\nname = \"{ITEM_NAME}\"\nthemes-dir = \".\"\n",
+        remote.display()
+    );
+    if let Some(value) = item_allow {
+        config.push_str(&format!("allow-dirty-update = {value}\n"));
+    }
+    config
+}
+
+/// Adds a commit on the remote's `main` that changes `file` to `contents`.
+fn remote_commit(remote: &Path, file: &str, contents: &str, message: &str) -> Result<()> {
+    fs::write(remote.join(file), contents)?;
+    git(remote, &["add", "-A"])?;
+    git(remote, &["commit", "-q", "-m", message])?;
+    Ok(())
+}
+
+#[test]
+fn update_carries_non_overlapping_local_changes_forward() -> Result<()> {
+    let f = fixture("allow_dirty_carry_forward")?;
+
+    // Local uncommitted edit to theme-a; upstream only advances theme-b.
+    fs::write(f.clone.join("theme-a.txt"), "my local edit\n")?;
+    remote_commit(&f.remote, "theme-b.txt", "b2\n", "advance b")?;
+
+    write_to_file(&f.config_path, &item_config(&f.remote, Some(true)))?;
+    let (stdout, _) = run_update(&f.command_vec)?;
+
+    ensure!(
+        stdout.contains(&format!("{ITEM_NAME} up to date (local changes preserved)")),
+        "Expected a preserved-changes success message.\nGot: {stdout}"
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-a.txt"))? == "my local edit\n",
+        "Local uncommitted edit should have been carried forward untouched."
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-b.txt"))? == "b2\n",
+        "Upstream change to theme-b should have been applied."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn update_refuses_and_preserves_work_on_overlapping_conflict() -> Result<()> {
+    let f = fixture("allow_dirty_overlap_conflict")?;
+
+    // Both the user and upstream change the same file.
+    fs::write(f.clone.join("theme-a.txt"), "my local edit\n")?;
+    remote_commit(&f.remote, "theme-a.txt", "upstream edit\n", "advance a")?;
+    let before = head(&f.clone)?;
+
+    write_to_file(&f.config_path, &item_config(&f.remote, Some(true)))?;
+    let (stdout, _) = run_update(&f.command_vec)?;
+
+    ensure!(
+        stdout.contains(&format!("{ITEM_NAME}: could not update")),
+        "Expected a friendly could-not-update message.\nGot: {stdout}"
+    );
+    ensure!(
+        stdout.contains("theme-a.txt"),
+        "Expected the conflicting file to be named.\nGot: {stdout}"
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-a.txt"))? == "my local edit\n",
+        "The user's uncommitted work must be left untouched."
+    );
+    ensure!(
+        head(&f.clone)? == before,
+        "HEAD must not move when the update is refused."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn update_refuses_when_incoming_file_collides_with_untracked() -> Result<()> {
+    let f = fixture("allow_dirty_untracked_collision")?;
+
+    // Upstream adds a new file that already exists locally as untracked.
+    remote_commit(&f.remote, "theme-c.txt", "upstream c\n", "add c")?;
+    fs::write(f.clone.join("theme-c.txt"), "my untracked c\n")?;
+
+    write_to_file(&f.config_path, &item_config(&f.remote, Some(true)))?;
+    let (stdout, _) = run_update(&f.command_vec)?;
+
+    ensure!(
+        stdout.contains(&format!("{ITEM_NAME}: could not update")),
+        "Expected a friendly could-not-update message.\nGot: {stdout}"
+    );
+    ensure!(
+        stdout.contains("theme-c.txt"),
+        "Expected the colliding untracked file to be named.\nGot: {stdout}"
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-c.txt"))? == "my untracked c\n",
+        "The untracked local file must be left untouched."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn update_is_blocked_when_flag_is_absent() -> Result<()> {
+    let f = fixture("allow_dirty_blocked_default")?;
+
+    fs::write(f.clone.join("theme-a.txt"), "my local edit\n")?;
+    remote_commit(&f.remote, "theme-b.txt", "b2\n", "advance b")?;
+
+    // No flag anywhere: defaults to the strict skip-if-dirty behavior.
+    write_to_file(&f.config_path, &item_config(&f.remote, None))?;
+    let (stdout, _) = run_update(&f.command_vec)?;
+
+    ensure!(
+        stdout.contains(&format!("{ITEM_NAME} contains uncommitted changes")),
+        "Expected the strict skip message.\nGot: {stdout}"
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-b.txt"))? == "b1\n",
+        "Upstream change must NOT be applied when the update is skipped."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn top_level_flag_applies_to_items_without_an_override() -> Result<()> {
+    let f = fixture("allow_dirty_global_default")?;
+
+    fs::write(f.clone.join("theme-a.txt"), "my local edit\n")?;
+    remote_commit(&f.remote, "theme-b.txt", "b2\n", "advance b")?;
+
+    // Top-level flag on; the item itself omits `allow-dirty-update`.
+    let config = format!(
+        "allow-dirty-update = true\n\n{}",
+        item_config(&f.remote, None)
+    );
+    write_to_file(&f.config_path, &config)?;
+    let (stdout, _) = run_update(&f.command_vec)?;
+
+    ensure!(
+        stdout.contains(&format!("{ITEM_NAME} up to date (local changes preserved)")),
+        "Top-level flag should enable lenient updates for the item.\nGot: {stdout}"
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-b.txt"))? == "b2\n",
+        "Upstream change should have been applied."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn conflict_is_detected_regardless_of_git_locale() -> Result<()> {
+    let f = fixture("allow_dirty_locale_independent")?;
+
+    fs::write(f.clone.join("theme-a.txt"), "my local edit\n")?;
+    remote_commit(&f.remote, "theme-a.txt", "upstream edit\n", "advance a")?;
+    let before = head(&f.clone)?;
+
+    write_to_file(&f.config_path, &item_config(&f.remote, Some(true)))?;
+
+    // Force a non-English locale. Even if git translates its overwrite message
+    // (or the locale is not installed and git falls back to English), the
+    // conflict must still be detected — detection relies on a plumbing exit
+    // code, not on the message text.
+    let (stdout, _) = run_command_with_env(
+        &f.command_vec,
+        &[("LC_ALL", "de_DE.UTF-8"), ("LANGUAGE", "de")],
+    )?;
+
+    ensure!(
+        stdout.contains(&format!("{ITEM_NAME}: could not update")),
+        "Conflict should be detected under a non-English locale.\nGot: {stdout}"
+    );
+    ensure!(
+        fs::read_to_string(f.clone.join("theme-a.txt"))? == "my local edit\n",
+        "The user's uncommitted work must be left untouched."
+    );
+    ensure!(
+        head(&f.clone)? == before,
+        "HEAD must not move when the update is refused."
+    );
+
+    Ok(())
+}

--- a/tests/cli_update_allow_dirty_tests.rs
+++ b/tests/cli_update_allow_dirty_tests.rs
@@ -219,27 +219,28 @@ fn update_is_blocked_when_flag_is_absent() -> Result<()> {
 }
 
 #[test]
-fn top_level_flag_applies_to_items_without_an_override() -> Result<()> {
-    let f = fixture("allow_dirty_global_default")?;
+fn schemes_setting_does_not_apply_to_items() -> Result<()> {
+    let f = fixture("allow_dirty_schemes_scope")?;
 
     fs::write(f.clone.join("theme-a.txt"), "my local edit\n")?;
     remote_commit(&f.remote, "theme-b.txt", "b2\n", "advance b")?;
 
-    // Top-level flag on; the item itself omits `allow-dirty-update`.
+    // `[schemes]` leniency is on, but the item does not opt in. The `[schemes]`
+    // setting governs only the built-in schemes repo, never `[[items]]`.
     let config = format!(
-        "allow-dirty-update = true\n\n{}",
+        "[schemes]\nallow-dirty-update = true\n\n{}",
         item_config(&f.remote, None)
     );
     write_to_file(&f.config_path, &config)?;
     let (stdout, _) = run_update(&f.command_vec)?;
 
     ensure!(
-        stdout.contains(&format!("{ITEM_NAME} up to date (local changes preserved)")),
-        "Top-level flag should enable lenient updates for the item.\nGot: {stdout}"
+        stdout.contains(&format!("{ITEM_NAME} contains uncommitted changes")),
+        "Item must not inherit the [schemes] setting.\nGot: {stdout}"
     );
     ensure!(
-        fs::read_to_string(f.clone.join("theme-b.txt"))? == "b2\n",
-        "Upstream change should have been applied."
+        fs::read_to_string(f.clone.join("theme-b.txt"))? == "b1\n",
+        "Item update must be skipped when the item itself does not opt in."
     );
 
     Ok(())

--- a/tests/cli_update_subcommand_tests.rs
+++ b/tests/cli_update_subcommand_tests.rs
@@ -397,3 +397,42 @@ revision = "43b36ed5eadad59a5027e442330d2485b8607b34"
 
     Ok(())
 }
+
+#[test]
+fn test_cli_update_schemes_repo_allow_dirty() -> Result<()> {
+    // -------
+    // Arrange
+    // -------
+    let (config_path, data_path, command_vec, _temp_dir) = setup(
+        "test_cli_update_schemes_repo_allow_dirty",
+        "update",
+        true, // clone cached repos, including the schemes repo
+    )?;
+
+    // Enable leniency for the built-in schemes repo via the `[schemes]` table.
+    write_to_file(&config_path, "[schemes]\nallow-dirty-update = true\n")?;
+
+    // Dirty the schemes repo with an untracked file, as custom schemes do.
+    let schemes_repo = data_path.join("repos/schemes");
+    let untracked = schemes_repo.join("custom-schemes-test.yaml");
+    write_to_file(&untracked, "system: \"base16\"\n")?;
+
+    // ---
+    // Act
+    // ---
+    let (stdout, _) = utils::run_command(&command_vec)?;
+
+    // ------
+    // Assert
+    // ------
+    ensure!(
+        stdout.contains("schemes up to date (local changes preserved)"),
+        "Expected the schemes repo to update leniently.\nGot: {stdout}"
+    );
+    ensure!(
+        untracked.exists(),
+        "Untracked file in the schemes repo should be preserved across the update."
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `allow-dirty-update` so `tinty update` (and `tinty sync`) can update a repo that has uncommitted/untracked changes instead of skipping it. Non-overlapping changes are carried forward; an update that would overwrite local work is refused atomically and git's own message is shown.

Set it per `[[items]]` entry, or under `[schemes]` for the built-in schemes repo:

```toml
[schemes]
allow-dirty-update = true

[[items]]
name = "..."
allow-dirty-update = true
```

## Relation to #179

Addresses the underlying friction — custom schemes leave untracked files, repos go dirty, and `update`/`sync` then refuse them — rather than the literal request (configurable `SCHEMES_REPO_URL`). It does **not** add `SCHEMES_REPO_URL` or change how custom schemes are built, so it shouldn't auto-close #179.

## Notes

Conflict detection is locale-independent: a failed checkout is classified with plumbing (the paths that differ between HEAD and the target, intersected with locally-modified/untracked paths) rather than by parsing git's translatable checkout message.
