### PR TITLE
feat(config): override the schemes repo source and revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@
   that would overwrite uncommitted work (or an untracked file) is refused and
   leaves the working tree untouched. Set it per `[[items]]` entry, or under the
   `[schemes]` table for the built-in schemes repo.
-  
+- Add `[schemes].path` and `[schemes].revision` config options to override the
+  source of the built-in schemes repository. `path` accepts an HTTPS Git URL
+  (cloned into `repos/schemes`) or a local directory (symlinked as
+  `repos/schemes`, without requiring it to be a Git repository); `revision`
+  pins a branch, tag, or commit SHA and is ignored for local paths. Either may
+  be set on its own, they follow the same install/update semantics as
+  `[[items]]`, and pointing `path` at Tinty's own managed schemes directory is
+  rejected as a circular reference.
+
 ### Fixed
 
 - Reject a config `[[items]]` entry named `schemes`, which is reserved for the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/README.md
+++ b/README.md
@@ -356,11 +356,30 @@ The `[schemes]` table holds settings for the built-in schemes repository
 
 | Key                  | Type      | Required | Description                                                                 | Default | Example                     |
 |----------------------|-----------|----------|-----------------------------------------------------------------------------|---------|-----------------------------|
+| `path`               | `string`  | Optional | Override the source of the schemes repository. A Git remote URL is cloned into `repos/schemes`; a local directory is symlinked as `repos/schemes` (and need not be a Git repository). When unset, the built-in `tinted-theming/schemes` repository is used. | Built-in schemes repo | `path = "https://github.com/me/my-schemes"` |
+| `revision`           | `string`  | Optional | Git revision (branch, tag, or commit SHA) to check out, mirroring an item's [`revision`](#items-table-configtoml-schema). **Ignored when `path` points at a local directory.** When unset alongside a custom `path`, the remote's default branch is used. | Built-in pinned revision | `revision = "main"` |
 | `allow-dirty-update` | `boolean` | Optional | Allow `tinty update` to update the schemes repo even when it has uncommitted changes. Behaves like an item's [`allow-dirty-update`](#note-on-allow-dirty-update). | `false` | `allow-dirty-update = true` |
+
+`path` and `revision` can be set independently: set only `revision` to re-pin
+the built-in repository to a different branch/tag/SHA, or set only `path` to
+swap the source while defaulting the revision. `path` follows the same rules as
+an item's `path` (HTTPS Git URL or a local directory; a leading `~/` is
+expanded). Pointing `path` at Tinty's own managed `repos/schemes` directory is
+rejected as a circular reference.
 
 ```toml
 [schemes]
+# Clone an alternate schemes repo at a specific branch:
+path = "https://github.com/me/my-schemes"
+revision = "main"
 allow-dirty-update = true
+```
+
+```toml
+[schemes]
+# Or symlink a local directory of schemes you are iterating on (revision is
+# ignored for local paths):
+path = "~/dev/my-schemes"
 ```
 
 ### Full Configuration Example

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::constants::{REPO_NAME, SCHEMES_REPO_NAME, SCHEMES_REPO_REVISION, SCHEMES_REPO_URL};
+use crate::utils::replace_tilde_slash_with_home;
 use anyhow::{anyhow, Context, Result};
 use home::home_dir;
 use serde::Deserialize;
@@ -184,26 +185,6 @@ fn ensure_item_name_is_unique(items: &[ConfigItem]) -> Result<()> {
     Ok(())
 }
 
-/// Expands a leading `~/` in a config path to the user's home directory,
-/// trimming surrounding whitespace. Paths without a `~/` prefix are returned
-/// as-is (trimmed).
-fn expand_tilde_path(path: &str) -> Result<String> {
-    let trimmed = path.trim();
-    trimmed.strip_prefix("~/").map_or_else(
-        || Ok(trimmed.to_string()),
-        |rest| {
-            home_dir().map_or_else(
-                || {
-                    Err(anyhow!(
-                        "Unable to determine a home directory for \"{trimmed}\", please use an absolute path instead"
-                    ))
-                },
-                |home| Ok(format!("{}/{rest}", home.display())),
-            )
-        },
-    )
-}
-
 fn ensure_ring_names_are_valid(rings: &[ConfigRing]) -> Result<()> {
     let mut names = HashSet::new();
 
@@ -345,7 +326,9 @@ impl Config {
         // URL or an existing local directory. Unlike an item, a local directory
         // need not be a Git repository.
         if let Some(raw_path) = config.schemes.path.clone() {
-            let expanded = expand_tilde_path(&raw_path)?;
+            let expanded = replace_tilde_slash_with_home(&raw_path)?
+                .to_string_lossy()
+                .into_owned();
 
             if Url::parse(&expanded).is_err() && !Path::new(&expanded).is_dir() {
                 return Err(anyhow!("config.toml [schemes].path \"{expanded}\" is not a valid url and is not a path to an existing local directory"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::constants::{REPO_NAME, SCHEMES_REPO_NAME};
+use crate::constants::{REPO_NAME, SCHEMES_REPO_NAME, SCHEMES_REPO_REVISION, SCHEMES_REPO_URL};
 use anyhow::{anyhow, Context, Result};
 use home::home_dir;
 use serde::Deserialize;
@@ -106,6 +106,49 @@ pub struct SchemesConfig {
     /// Defaults to `false`, preserving the strict skip-if-dirty behavior.
     #[serde(default, rename = "allow-dirty-update")]
     pub allow_dirty_update: bool,
+    /// Overrides the source of the built-in schemes repository. May be a Git
+    /// remote URL (cloned into `repos/schemes`) or a local directory (symlinked
+    /// as `repos/schemes`). When unset, the built-in
+    /// `tinted-theming/schemes` repo is used. A local directory need not be a
+    /// Git repository.
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Git revision (branch, tag, or commit SHA) to check out for the schemes
+    /// repo, mirroring an item's `revision`. Ignored when `path` points at a
+    /// local directory. When unset and `path` is unset, the built-in pinned
+    /// revision is used.
+    #[serde(default)]
+    pub revision: Option<String>,
+}
+
+/// Rejects a `[schemes].path` (a local directory) that resolves to tinty's own
+/// managed schemes directory (`repos/schemes`). Symlinking that slot to itself,
+/// or cloning it into itself, is a circular reference. Git URL sources can never
+/// name the local slot, so they are always accepted here.
+pub fn ensure_schemes_path_not_circular(source: &str, schemes_repo_path: &Path) -> Result<()> {
+    if Url::parse(source).is_ok() {
+        return Ok(());
+    }
+
+    // Identity of the schemes-repo slot itself, computed without dereferencing a
+    // symlink that may already occupy it (canonicalizing the slot directly would
+    // follow such a symlink and produce a false positive on repeat runs).
+    let slot_identity = schemes_repo_path
+        .parent()
+        .and_then(|parent| parent.canonicalize().ok())
+        .zip(schemes_repo_path.file_name())
+        .map(|(parent, name)| parent.join(name));
+
+    if let (Ok(source_canon), Some(slot)) = (Path::new(source).canonicalize(), slot_identity) {
+        if source_canon == slot {
+            return Err(anyhow!(
+                "config.toml [schemes].path points at {REPO_NAME}'s own managed schemes directory ({}). This would create a circular reference; point it at a different directory or a Git URL.",
+                schemes_repo_path.display()
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Structure for configuration
@@ -141,6 +184,26 @@ fn ensure_item_name_is_unique(items: &[ConfigItem]) -> Result<()> {
     Ok(())
 }
 
+/// Expands a leading `~/` in a config path to the user's home directory,
+/// trimming surrounding whitespace. Paths without a `~/` prefix are returned
+/// as-is (trimmed).
+fn expand_tilde_path(path: &str) -> Result<String> {
+    let trimmed = path.trim();
+    trimmed.strip_prefix("~/").map_or_else(
+        || Ok(trimmed.to_string()),
+        |rest| {
+            home_dir().map_or_else(
+                || {
+                    Err(anyhow!(
+                        "Unable to determine a home directory for \"{trimmed}\", please use an absolute path instead"
+                    ))
+                },
+                |home| Ok(format!("{}/{rest}", home.display())),
+            )
+        },
+    )
+}
+
 fn ensure_ring_names_are_valid(rings: &[ConfigRing]) -> Result<()> {
     let mut names = HashSet::new();
 
@@ -158,6 +221,33 @@ fn ensure_ring_names_are_valid(rings: &[ConfigRing]) -> Result<()> {
 }
 
 impl Config {
+    /// Resolves the effective source and revision for the built-in schemes
+    /// repository from the `[schemes]` table.
+    ///
+    /// Returns the source (a Git URL or local directory) and the revision to
+    /// check out (`None` lets the repository backend pick its default, matching
+    /// `[[items]]`). Backwards-compatible: with neither `path` nor `revision`
+    /// set, this is exactly the built-in repo pinned at its default revision.
+    /// A `revision` may be set on its own to re-pin the built-in repo, and a
+    /// `path` may be set on its own to swap the source while defaulting the
+    /// revision.
+    pub fn schemes_source(&self) -> (String, Option<String>) {
+        self.schemes.path.as_ref().map_or_else(
+            || {
+                (
+                    SCHEMES_REPO_URL.to_string(),
+                    Some(
+                        self.schemes
+                            .revision
+                            .clone()
+                            .unwrap_or_else(|| SCHEMES_REPO_REVISION.to_string()),
+                    ),
+                )
+            },
+            |path| (path.clone(), self.schemes.revision.clone()),
+        )
+    }
+
     pub fn read(path: &Path) -> Result<Self> {
         if path.exists() && !path.is_file() {
             return Err(anyhow!(
@@ -250,6 +340,20 @@ impl Config {
             }
         }
 
+        // Normalize and validate the optional `[schemes].path` the same way item
+        // paths are handled: expand a leading `~/`, then require it be a valid
+        // URL or an existing local directory. Unlike an item, a local directory
+        // need not be a Git repository.
+        if let Some(raw_path) = config.schemes.path.clone() {
+            let expanded = expand_tilde_path(&raw_path)?;
+
+            if Url::parse(&expanded).is_err() && !Path::new(&expanded).is_dir() {
+                return Err(anyhow!("config.toml [schemes].path \"{expanded}\" is not a valid url and is not a path to an existing local directory"));
+            }
+
+            config.schemes.path = Some(expanded);
+        }
+
         if !shell.contains("{}") {
             let msg = "The configured shell does not contain the required command placeholder '{}'. Check the default file or github for config examples.";
             return Err(anyhow!(msg));
@@ -298,9 +402,20 @@ impl fmt::Display for Config {
 
         // Emitted before the `[[rings]]`/`[[items]]` array-of-tables so its
         // keys are not mis-parsed as belonging to the last array entry.
-        if self.schemes.allow_dirty_update {
+        if self.schemes.path.is_some()
+            || self.schemes.revision.is_some()
+            || self.schemes.allow_dirty_update
+        {
             writeln!(f, "\n[schemes]")?;
-            writeln!(f, "allow-dirty-update = true")?;
+            if let Some(path) = &self.schemes.path {
+                writeln!(f, "path = \"{path}\"")?;
+            }
+            if let Some(revision) = &self.schemes.revision {
+                writeln!(f, "revision = \"{revision}\"")?;
+            }
+            if self.schemes.allow_dirty_update {
+                writeln!(f, "allow-dirty-update = true")?;
+            }
         }
 
         if let Some(rings) = &self.rings {
@@ -392,5 +507,95 @@ themes-dir = "themes"
 
         let off: Config = toml::from_str("shell = \"sh -c '{}'\"\n").unwrap();
         assert!(!off.to_string().contains("[schemes]"));
+    }
+
+    #[test]
+    fn schemes_source_defaults_to_builtin_repo_and_revision() {
+        // Backwards-compatible default: no `[schemes]` table at all.
+        let config: Config = toml::from_str("shell = \"sh -c '{}'\"\n").unwrap();
+        let (source, revision) = config.schemes_source();
+        assert_eq!(source, super::SCHEMES_REPO_URL);
+        assert_eq!(revision.as_deref(), Some(super::SCHEMES_REPO_REVISION));
+    }
+
+    #[test]
+    fn schemes_source_revision_only_repins_builtin_repo() {
+        let config: Config = toml::from_str("[schemes]\nrevision = \"main\"\n").unwrap();
+        let (source, revision) = config.schemes_source();
+        assert_eq!(source, super::SCHEMES_REPO_URL);
+        assert_eq!(revision.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn schemes_source_path_overrides_source_and_defaults_revision() {
+        let config: Config =
+            toml::from_str("[schemes]\npath = \"https://example.com/schemes\"\n").unwrap();
+        let (source, revision) = config.schemes_source();
+        assert_eq!(source, "https://example.com/schemes");
+        // No revision given for a custom source => backend default (None).
+        assert_eq!(revision, None);
+    }
+
+    #[test]
+    fn schemes_source_path_and_revision_are_both_honored() {
+        let config: Config = toml::from_str(
+            "[schemes]\npath = \"https://example.com/schemes\"\nrevision = \"v1.0.0\"\n",
+        )
+        .unwrap();
+        let (source, revision) = config.schemes_source();
+        assert_eq!(source, "https://example.com/schemes");
+        assert_eq!(revision.as_deref(), Some("v1.0.0"));
+    }
+
+    #[test]
+    fn schemes_path_and_revision_parse_and_render() {
+        let mut config: Config = toml::from_str(
+            "[schemes]\npath = \"https://example.com/schemes\"\nrevision = \"dev\"\n",
+        )
+        .unwrap();
+        config.shell = Some("sh -c '{}'".to_string());
+        assert_eq!(
+            config.schemes.path.as_deref(),
+            Some("https://example.com/schemes")
+        );
+        assert_eq!(config.schemes.revision.as_deref(), Some("dev"));
+
+        let rendered = config.to_string();
+        assert!(rendered.contains("[schemes]"));
+        assert!(rendered.contains("path = \"https://example.com/schemes\""));
+        assert!(rendered.contains("revision = \"dev\""));
+    }
+
+    #[test]
+    fn ensure_schemes_path_not_circular_allows_urls_and_other_dirs() {
+        use std::path::Path;
+        // A URL source is never circular.
+        assert!(super::ensure_schemes_path_not_circular(
+            "https://example.com/schemes",
+            Path::new("/does/not/matter/repos/schemes"),
+        )
+        .is_ok());
+
+        // A local dir that differs from the slot is fine. Use the temp dir,
+        // which exists, as the source and a distinct slot path.
+        let tmp = std::env::temp_dir();
+        assert!(super::ensure_schemes_path_not_circular(
+            tmp.to_str().unwrap(),
+            &tmp.join("some-other-data/repos/schemes"),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn ensure_schemes_path_not_circular_rejects_self_reference() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repos = tmp.path().join("repos");
+        let slot = repos.join("schemes");
+        std::fs::create_dir_all(&slot).unwrap();
+
+        // Pointing `[schemes].path` at the slot itself is circular.
+        let err = super::ensure_schemes_path_not_circular(slot.to_str().unwrap(), &slot)
+            .expect_err("expected a circular-reference error");
+        assert!(err.to_string().contains("circular reference"));
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -9,3 +9,5 @@ pub const CUSTOM_SCHEMES_DIR_NAME: &str = "custom-schemes";
 pub const CURRENT_SCHEME_FILE_NAME: &str = "current_scheme";
 pub const DEFAULT_SCHEME_SYSTEM: &str = "base16";
 pub const SCHEMES_REPO_REVISION: &str = "spec-0.11";
+/// Fallback Git revision used when a repository has no configured `revision`.
+pub const DEFAULT_REVISION: &str = "main";

--- a/src/operations/install.rs
+++ b/src/operations/install.rs
@@ -75,47 +75,72 @@ fn install_dir(
     Ok(())
 }
 
-/// The kind of entry the managed `repos/schemes` slot should hold, derived from
-/// the configured schemes source.
-enum SchemesSlotKind {
-    /// A Git clone of a remote URL.
-    Clone,
-    /// A symlink to a local directory.
-    Symlink,
+/// Normalizes a Git URL for equality checks by trimming a trailing slash and a
+/// `.git` suffix, so `.../schemes`, `.../schemes/`, and `.../schemes.git` all
+/// compare equal. Used only to decide whether an existing clone already points
+/// at the configured source; the stored URL is never rewritten.
+fn git_url_eq(a: &str, b: &str) -> bool {
+    fn normalize(url: &str) -> &str {
+        let url = url.trim().trim_end_matches('/');
+        url.strip_suffix(".git").unwrap_or(url)
+    }
+    normalize(a) == normalize(b)
 }
 
-/// Reconciles the `repos/schemes` slot with the desired kind before
-/// (re)installing it. When the configured schemes source switches between a Git
-/// URL and a local path, the previously-installed form is removed so the correct
-/// one can take its place. A matching kind — or an empty slot — is left
-/// untouched, so the normal `install_git_url`/`install_dir` fast paths still
-/// run.
-fn reconcile_schemes_slot(schemes_repo_path: &Path, want: &SchemesSlotKind) -> Result<()> {
+/// Prepares the `repos/schemes` slot to hold a fresh clone of `source`. Removes
+/// a symlink left by a previous local-path source, or a stale clone whose
+/// `origin` points at a different URL, so `install_git_url` re-clones from the
+/// now-configured source. A clone already pointing at `source` (or an empty
+/// slot) is left untouched, so the common case does no extra work.
+fn prepare_clone_slot(schemes_repo_path: &Path, source: &str) -> Result<()> {
     let Ok(metadata) = symlink_metadata(schemes_repo_path) else {
-        // Nothing occupies the slot yet.
-        return Ok(());
+        return Ok(()); // Nothing occupies the slot yet.
     };
-    let is_symlink = metadata.file_type().is_symlink();
 
-    match (want, is_symlink) {
-        // Want a clone, but a symlink to a local dir is here: drop the symlink.
-        (SchemesSlotKind::Clone, true) => remove_symlink(schemes_repo_path).with_context(|| {
+    if metadata.file_type().is_symlink() {
+        return remove_symlink(schemes_repo_path).with_context(|| {
             format!(
                 "Failed to remove existing schemes symlink at {}",
                 schemes_repo_path.display()
             )
-        }),
-        // Want a symlink, but a real directory (a clone) is here: remove it.
-        (SchemesSlotKind::Symlink, false) => std::fs::remove_dir_all(schemes_repo_path)
-            .with_context(|| {
-                format!(
-                    "Failed to remove existing schemes clone at {}",
-                    schemes_repo_path.display()
-                )
-            }),
-        // Already the right kind; leave it for the installer to refresh.
-        _ => Ok(()),
+        });
     }
+
+    // A real directory: an existing clone. Re-clone only when its origin no
+    // longer matches the configured source.
+    let matches_source =
+        repo::origin_url(schemes_repo_path)?.is_some_and(|origin| git_url_eq(&origin, source));
+    if !matches_source {
+        std::fs::remove_dir_all(schemes_repo_path).with_context(|| {
+            format!(
+                "Failed to remove existing schemes clone at {}",
+                schemes_repo_path.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Prepares the `repos/schemes` slot to hold a symlink to a local directory.
+/// Removes a clone left by a previous Git-URL source so `install_dir` can create
+/// the symlink. An existing symlink (or empty slot) is left for `install_dir` to
+/// refresh.
+fn prepare_symlink_slot(schemes_repo_path: &Path) -> Result<()> {
+    let Ok(metadata) = symlink_metadata(schemes_repo_path) else {
+        return Ok(()); // Nothing occupies the slot yet.
+    };
+
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+
+    std::fs::remove_dir_all(schemes_repo_path).with_context(|| {
+        format!(
+            "Failed to remove existing schemes clone at {}",
+            schemes_repo_path.display()
+        )
+    })
 }
 
 /// Installs the built-in schemes repository from its configured source. A Git
@@ -129,7 +154,7 @@ fn install_schemes_repo(
     is_quiet: bool,
 ) -> Result<()> {
     if Url::parse(source).is_ok() {
-        reconcile_schemes_slot(schemes_repo_path, &SchemesSlotKind::Clone)?;
+        prepare_clone_slot(schemes_repo_path, source)?;
         install_git_url(
             schemes_repo_path,
             SCHEMES_REPO_NAME,
@@ -138,7 +163,7 @@ fn install_schemes_repo(
             is_quiet,
         )
     } else {
-        reconcile_schemes_slot(schemes_repo_path, &SchemesSlotKind::Symlink)?;
+        prepare_symlink_slot(schemes_repo_path)?;
         install_dir(
             schemes_repo_path,
             SCHEMES_REPO_NAME,

--- a/src/operations/install.rs
+++ b/src/operations/install.rs
@@ -1,7 +1,7 @@
-use crate::config::Config;
-use crate::constants::{REPO_DIR, SCHEMES_REPO_NAME, SCHEMES_REPO_REVISION, SCHEMES_REPO_URL};
+use crate::config::{ensure_schemes_path_not_circular, Config};
+use crate::constants::{REPO_DIR, SCHEMES_REPO_NAME};
 use crate::repo;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use std::fs::{remove_file as remove_symlink, symlink_metadata};
 use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
@@ -75,12 +75,86 @@ fn install_dir(
     Ok(())
 }
 
+/// The kind of entry the managed `repos/schemes` slot should hold, derived from
+/// the configured schemes source.
+enum SchemesSlotKind {
+    /// A Git clone of a remote URL.
+    Clone,
+    /// A symlink to a local directory.
+    Symlink,
+}
+
+/// Reconciles the `repos/schemes` slot with the desired kind before
+/// (re)installing it. When the configured schemes source switches between a Git
+/// URL and a local path, the previously-installed form is removed so the correct
+/// one can take its place. A matching kind — or an empty slot — is left
+/// untouched, so the normal `install_git_url`/`install_dir` fast paths still
+/// run.
+fn reconcile_schemes_slot(schemes_repo_path: &Path, want: &SchemesSlotKind) -> Result<()> {
+    let Ok(metadata) = symlink_metadata(schemes_repo_path) else {
+        // Nothing occupies the slot yet.
+        return Ok(());
+    };
+    let is_symlink = metadata.file_type().is_symlink();
+
+    match (want, is_symlink) {
+        // Want a clone, but a symlink to a local dir is here: drop the symlink.
+        (SchemesSlotKind::Clone, true) => remove_symlink(schemes_repo_path).with_context(|| {
+            format!(
+                "Failed to remove existing schemes symlink at {}",
+                schemes_repo_path.display()
+            )
+        }),
+        // Want a symlink, but a real directory (a clone) is here: remove it.
+        (SchemesSlotKind::Symlink, false) => std::fs::remove_dir_all(schemes_repo_path)
+            .with_context(|| {
+                format!(
+                    "Failed to remove existing schemes clone at {}",
+                    schemes_repo_path.display()
+                )
+            }),
+        // Already the right kind; leave it for the installer to refresh.
+        _ => Ok(()),
+    }
+}
+
+/// Installs the built-in schemes repository from its configured source. A Git
+/// URL is cloned into `repos/schemes`; a local directory is symlinked as
+/// `repos/schemes` (with `revision` ignored, exactly like a local-path
+/// `[[items]]` entry).
+fn install_schemes_repo(
+    schemes_repo_path: &Path,
+    source: &str,
+    revision: Option<&str>,
+    is_quiet: bool,
+) -> Result<()> {
+    if Url::parse(source).is_ok() {
+        reconcile_schemes_slot(schemes_repo_path, &SchemesSlotKind::Clone)?;
+        install_git_url(
+            schemes_repo_path,
+            SCHEMES_REPO_NAME,
+            source,
+            revision,
+            is_quiet,
+        )
+    } else {
+        reconcile_schemes_slot(schemes_repo_path, &SchemesSlotKind::Symlink)?;
+        install_dir(
+            schemes_repo_path,
+            SCHEMES_REPO_NAME,
+            Path::new(source),
+            is_quiet,
+        )
+    }
+}
+
 /// Install cli tool
 ///
 /// Clones the provided config repositories and ensures everything is ready for when the user runs
 /// any other command
 pub fn install(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<()> {
     let config = Config::read(config_path)?;
+    let (schemes_source, schemes_revision) = config.schemes_source();
     let items = config.items.unwrap_or_default();
     let hooks_path = data_path.join(REPO_DIR);
 
@@ -102,11 +176,11 @@ pub fn install(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<(
 
     let schemes_repo_path = hooks_path.join(SCHEMES_REPO_NAME);
 
-    install_git_url(
+    ensure_schemes_path_not_circular(&schemes_source, &schemes_repo_path)?;
+    install_schemes_repo(
         &schemes_repo_path,
-        SCHEMES_REPO_NAME,
-        SCHEMES_REPO_URL,
-        Some(SCHEMES_REPO_REVISION),
+        &schemes_source,
+        schemes_revision.as_deref(),
         is_quiet,
     )?;
 

--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -1,5 +1,5 @@
 use crate::config::{ensure_schemes_path_not_circular, Config};
-use crate::constants::{REPO_DIR, REPO_NAME, SCHEMES_REPO_NAME};
+use crate::constants::{DEFAULT_REVISION, REPO_DIR, REPO_NAME, SCHEMES_REPO_NAME};
 use crate::repo::{self, UpdateStatus};
 use anyhow::{Context, Result};
 use std::path::Path;
@@ -14,7 +14,7 @@ fn update_item(
     is_quiet: bool,
 ) -> Result<()> {
     if item_path.is_dir() {
-        let rev = revision.unwrap_or("main");
+        let rev = revision.unwrap_or(DEFAULT_REVISION);
         let is_clean = repo::is_clean(item_path)?;
 
         if is_clean {

--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -1,8 +1,9 @@
-use crate::constants::{REPO_DIR, SCHEMES_REPO_NAME, SCHEMES_REPO_REVISION, SCHEMES_REPO_URL};
+use crate::config::{ensure_schemes_path_not_circular, Config};
+use crate::constants::{REPO_DIR, REPO_NAME, SCHEMES_REPO_NAME};
 use crate::repo::{self, UpdateStatus};
-use crate::{config::Config, constants::REPO_NAME};
 use anyhow::{Context, Result};
 use std::path::Path;
+use url::Url;
 
 fn update_item(
     item_name: &str,
@@ -58,6 +59,39 @@ fn print_conflict_message(item_name: &str, git_stderr: &str) {
     }
 }
 
+/// Updates the built-in schemes repository from its configured source.
+///
+/// A Git URL source is pulled to its revision exactly like an item. A local-path
+/// source is a live symlink to the user's directory, so there is nothing to
+/// fetch and `revision` is irrelevant — we only confirm the symlink is in place.
+fn update_schemes_repo(
+    schemes_repo_path: &Path,
+    source: &str,
+    revision: Option<&str>,
+    allow_dirty: bool,
+    is_quiet: bool,
+) -> Result<()> {
+    if Url::parse(source).is_ok() {
+        update_item(
+            SCHEMES_REPO_NAME,
+            source,
+            schemes_repo_path,
+            revision,
+            allow_dirty,
+            is_quiet,
+        )
+    } else {
+        if !is_quiet {
+            if schemes_repo_path.exists() {
+                println!("{SCHEMES_REPO_NAME} up to date (local directory)");
+            } else {
+                println!("{SCHEMES_REPO_NAME} not installed (run `{REPO_NAME} install`)");
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Updates local files
 ///
 /// Updates the provided repositories in config file by doing a git pull
@@ -66,6 +100,7 @@ pub fn update(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<()
     // The built-in schemes repo has no `[[items]]` entry, so its leniency is
     // configured separately under `[schemes]`.
     let schemes_allow_dirty = config.schemes.allow_dirty_update;
+    let (schemes_source, schemes_revision) = config.schemes_source();
     let items = config.items.unwrap_or_default();
     let hooks_path = data_path.join(REPO_DIR);
 
@@ -84,11 +119,11 @@ pub fn update(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<()
 
     let schemes_repo_path = hooks_path.join(SCHEMES_REPO_NAME);
 
-    update_item(
-        SCHEMES_REPO_NAME,
-        SCHEMES_REPO_URL,
+    ensure_schemes_path_not_circular(&schemes_source, &schemes_repo_path)?;
+    update_schemes_repo(
         &schemes_repo_path,
-        Some(SCHEMES_REPO_REVISION),
+        &schemes_source,
+        schemes_revision.as_deref(),
         schemes_allow_dirty,
         is_quiet,
     )?;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -39,6 +39,9 @@ pub trait RepositoryBackend {
         allow_dirty: bool,
     ) -> Result<UpdateStatus>;
     fn is_clean(&self, target: &Path) -> Result<bool>;
+    /// Returns the URL of the `origin` remote for the repository at `target`,
+    /// or `None` when `target` is not a git repository or has no such remote.
+    fn origin_url(&self, target: &Path) -> Result<Option<String>>;
 }
 
 /// Returns the active repository backend for this invocation.
@@ -65,4 +68,8 @@ pub fn update(
 
 pub fn is_clean(target: &Path) -> Result<bool> {
     backend().is_clean(target)
+}
+
+pub fn origin_url(target: &Path) -> Result<Option<String>> {
+    backend().origin_url(target)
 }

--- a/src/repo/git_shell.rs
+++ b/src/repo/git_shell.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::module_name_repetitions)]
 
+use crate::constants::DEFAULT_REVISION;
 use crate::repo::{RepositoryBackend, UpdateStatus};
 use anyhow::{anyhow, Context, Error, Result};
 use rand::Rng;
@@ -31,6 +32,31 @@ impl RepositoryBackend for GitShellBackend {
     fn is_clean(&self, target: &Path) -> Result<bool> {
         git_is_working_dir_clean(target)
     }
+
+    fn origin_url(&self, target: &Path) -> Result<Option<String>> {
+        git_origin_url(target)
+    }
+}
+
+/// Reads the `origin` remote URL of the repository at `target`. Returns `None`
+/// when `target` is not a git repository or has no `origin` remote, so callers
+/// can treat "unknown" the same as "does not match".
+fn git_origin_url(target: &Path) -> Result<Option<String>> {
+    if !target.is_dir() {
+        return Ok(None);
+    }
+
+    let output = safe_command("git remote get-url origin", target)?
+        .stderr(Stdio::null())
+        .output()
+        .with_context(|| format!("Failed to read origin remote in {}", target.display()))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok((!url.is_empty()).then_some(url))
 }
 
 fn git_clone(repo_url: &str, target_dir: &Path, revision: Option<&str>) -> Result<()> {
@@ -116,7 +142,7 @@ fn git_update(
         )
     })?;
 
-    let revision_str = revision.unwrap_or("main");
+    let revision_str = revision.unwrap_or(DEFAULT_REVISION);
     let res = git_to_revision(repo_path, &tmp_remote_name, revision_str, allow_dirty);
 
     let status = match res {

--- a/tests/cli_schemes_repo_tests.rs
+++ b/tests/cli_schemes_repo_tests.rs
@@ -1,0 +1,412 @@
+//! Integration tests for overriding the built-in schemes repository via the
+//! `[schemes]` table's `path` and `revision` keys.
+//!
+//! The override tests are fully offline and deterministic: they build throwaway
+//! **local** git repositories (addressed with `file://` URLs to exercise the
+//! clone path) and plain local directories (to exercise the symlink path). Each
+//! config also declares a local-directory `[[items]]` entry so that `install`
+//! never falls back to cloning the default `tinted-shell` item over the network.
+//!
+//! The backwards-compatibility test uses the cached real schemes repo (network
+//! on first run only, like the other suites).
+
+mod utils;
+
+use std::fs;
+use std::fs::symlink_metadata;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{ensure, Context, Result};
+use utils::{build_command_vec, run_command, setup, write_to_file};
+
+fn git(dir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .with_context(|| format!("failed to run git {args:?} in {}", dir.display()))?;
+    ensure!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn head(dir: &Path) -> Result<String> {
+    Ok(git(dir, &["rev-parse", "HEAD"])?.trim().to_string())
+}
+
+/// A minimal, valid base16 scheme YAML for the given slug.
+fn scheme_yaml(slug: &str, name: &str) -> String {
+    format!(
+        "system: base16\nname: {name}\nslug: {slug}\nauthor: Tinty Test\nvariant: dark\npalette:\n  base00: '#282628'\n  base01: '#403e3f'\n  base02: '#595757'\n  base03: '#71706e'\n  base04: '#8a8986'\n  base05: '#a2a29d'\n  base06: '#bbbbb5'\n  base07: '#d4d4cd'\n  base08: '#bf2546'\n  base09: '#f69622'\n  base0A: '#f99923'\n  base0B: '#19953f'\n  base0C: '#40dab9'\n  base0D: '#0666dc'\n  base0E: '#8554ac'\n  base0F: '#ac7424'\n"
+    )
+}
+
+/// Writes `base16/<slug>.yaml` under `dir`, creating the system subdir.
+fn write_scheme(dir: &Path, slug: &str, name: &str) -> Result<()> {
+    write_to_file(
+        dir.join("base16").join(format!("{slug}.yaml")),
+        &scheme_yaml(slug, name),
+    )
+}
+
+/// Initializes a git repo at `dir` on `main` with a single base16 scheme.
+fn git_init(dir: &Path) -> Result<()> {
+    fs::create_dir_all(dir)?;
+    git(dir, &["init", "-q", "-b", "main"])?;
+    git(dir, &["config", "user.email", "tinty@test.local"])?;
+    git(dir, &["config", "user.name", "tinty test"])?;
+    // Never sign throwaway test commits — commit signing (e.g. via 1Password)
+    // would otherwise hang or fail in CI/dev environments.
+    git(dir, &["config", "commit.gpgsign", "false"])?;
+    Ok(())
+}
+
+fn init_scheme_repo(dir: &Path, slug: &str, name: &str) -> Result<()> {
+    git_init(dir)?;
+    write_scheme(dir, slug, name)?;
+    git(dir, &["add", "-A"])?;
+    git(dir, &["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+/// A `file://` URL for a local directory, so tinty treats it as a Git remote to
+/// clone rather than a local path to symlink.
+fn file_url(path: &Path) -> String {
+    format!("file://{}", path.display())
+}
+
+/// A `[[items]]` entry backed by a throwaway local git repo (addressed by
+/// `file://`), so both `install` and `update` work offline without falling back
+/// to cloning the default `tinted-shell` item over the network.
+fn local_item_config(temp: &Path) -> Result<String> {
+    let item_dir = temp.join("localitem-remote");
+    // Idempotent: create the throwaway remote once, then reuse it across
+    // repeated calls within a single test.
+    if !item_dir.join(".git").exists() {
+        git_init(&item_dir)?;
+        write_to_file(item_dir.join("placeholder.txt"), "placeholder\n")?;
+        git(&item_dir, &["add", "-A"])?;
+        git(&item_dir, &["commit", "-q", "-m", "init"])?;
+    }
+    Ok(format!(
+        "[[items]]\npath = \"{}\"\nname = \"localitem\"\nthemes-dir = \".\"\n",
+        file_url(&item_dir)
+    ))
+}
+
+fn schemes_repo_path(data_path: &Path) -> PathBuf {
+    data_path.join("repos").join("schemes")
+}
+
+fn is_symlink(path: &Path) -> Result<bool> {
+    Ok(symlink_metadata(path)?.file_type().is_symlink())
+}
+
+// -----------------------------------------------------------------------------
+// Git URL source
+// -----------------------------------------------------------------------------
+
+#[test]
+fn schemes_url_source_is_cloned_not_symlinked() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_url_source_is_cloned", "install", false)?;
+
+    let remote = temp.path().join("custom-schemes");
+    init_scheme_repo(&remote, "custom-red", "Custom Red")?;
+
+    let config = format!(
+        "[schemes]\npath = \"{}\"\n\n{}",
+        file_url(&remote),
+        local_item_config(temp.path())?
+    );
+    write_to_file(&config_path, &config)?;
+
+    let (_stdout, _stderr) = run_command(&command_vec)?;
+
+    let schemes = schemes_repo_path(&data_path);
+    ensure!(
+        !is_symlink(&schemes)?,
+        "A Git URL source must be a clone, not a symlink."
+    );
+    ensure!(
+        schemes.join(".git").exists(),
+        "The cloned schemes repo should contain a .git directory."
+    );
+
+    // The custom scheme is discoverable via `tinty list`.
+    let list_vec = build_command_vec("list", &config_path, &data_path)?;
+    let (stdout, _) = run_command(&list_vec)?;
+    ensure!(
+        stdout.contains("base16-custom-red"),
+        "Expected the custom scheme to be listed.\nGot: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn schemes_revision_is_checked_out() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_revision_is_checked_out", "install", false)?;
+
+    // main advances past a tagged/branched revision that has a distinct scheme.
+    let remote = temp.path().join("custom-schemes");
+    init_scheme_repo(&remote, "pinned-scheme", "Pinned")?;
+    let pinned_sha = head(&remote)?;
+    git(&remote, &["branch", "stable"])?;
+    // Advance main so it differs from `stable`.
+    write_scheme(&remote, "moving-scheme", "Moving")?;
+    git(&remote, &["add", "-A"])?;
+    git(&remote, &["commit", "-q", "-m", "advance main"])?;
+
+    let config = format!(
+        "[schemes]\npath = \"{}\"\nrevision = \"stable\"\n\n{}",
+        file_url(&remote),
+        local_item_config(temp.path())?
+    );
+    write_to_file(&config_path, &config)?;
+
+    run_command(&command_vec)?;
+
+    let schemes = schemes_repo_path(&data_path);
+    ensure!(
+        head(&schemes)? == pinned_sha,
+        "The schemes repo should be checked out at the pinned revision."
+    );
+    ensure!(
+        !schemes.join("base16").join("moving-scheme.yaml").exists(),
+        "The revision must not include content added after it on main."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn schemes_update_pulls_from_url_source() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_update_pulls_from_url_source", "install", false)?;
+
+    let remote = temp.path().join("custom-schemes");
+    init_scheme_repo(&remote, "first-scheme", "First")?;
+
+    let config = format!(
+        "[schemes]\npath = \"{}\"\n\n{}",
+        file_url(&remote),
+        local_item_config(temp.path())?
+    );
+    write_to_file(&config_path, &config)?;
+
+    run_command(&command_vec)?;
+
+    // Advance the remote's main branch with a new scheme, then update.
+    write_scheme(&remote, "second-scheme", "Second")?;
+    git(&remote, &["add", "-A"])?;
+    git(&remote, &["commit", "-q", "-m", "add second"])?;
+
+    let update_vec = build_command_vec("update", &config_path, &data_path)?;
+    let (stdout, _) = run_command(&update_vec)?;
+    ensure!(
+        stdout.contains("schemes up to date"),
+        "Expected the schemes repo to report an update.\nGot: {stdout}"
+    );
+    ensure!(
+        schemes_repo_path(&data_path)
+            .join("base16")
+            .join("second-scheme.yaml")
+            .exists(),
+        "The update should have pulled the newly-added scheme."
+    );
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Local path source (symlink)
+// -----------------------------------------------------------------------------
+
+#[test]
+fn schemes_local_path_is_symlinked_and_revision_ignored() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_local_path_symlinked", "install", false)?;
+
+    // A plain local directory (NOT a git repo) holding schemes.
+    let local_schemes = temp.path().join("local-schemes");
+    write_scheme(&local_schemes, "local-green", "Local Green")?;
+
+    // A revision is set but must be ignored for a local-path source.
+    let config = format!(
+        "[schemes]\npath = \"{}\"\nrevision = \"does-not-exist\"\n\n{}",
+        local_schemes.display(),
+        local_item_config(temp.path())?
+    );
+    write_to_file(&config_path, &config)?;
+
+    let (_stdout, stderr) = run_command(&command_vec)?;
+    ensure!(
+        stderr.is_empty() || !stderr.contains("does-not-exist"),
+        "The revision must be ignored for a local-path source.\nstderr: {stderr}"
+    );
+
+    let schemes = schemes_repo_path(&data_path);
+    ensure!(
+        is_symlink(&schemes)?,
+        "A local-path source must be installed as a symlink."
+    );
+
+    // The local scheme is discoverable via `tinty list` — no git required.
+    let list_vec = build_command_vec("list", &config_path, &data_path)?;
+    let (stdout, _) = run_command(&list_vec)?;
+    ensure!(
+        stdout.contains("base16-local-green"),
+        "Expected the local scheme to be listed.\nGot: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn schemes_local_path_update_is_noop() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_local_path_update_noop", "install", false)?;
+
+    let local_schemes = temp.path().join("local-schemes");
+    write_scheme(&local_schemes, "local-blue", "Local Blue")?;
+
+    let config = format!(
+        "[schemes]\npath = \"{}\"\n\n{}",
+        local_schemes.display(),
+        local_item_config(temp.path())?
+    );
+    write_to_file(&config_path, &config)?;
+
+    run_command(&command_vec)?;
+
+    let update_vec = build_command_vec("update", &config_path, &data_path)?;
+    let (stdout, _) = run_command(&update_vec)?;
+    ensure!(
+        stdout.contains("schemes up to date (local directory)"),
+        "A local-path schemes source should report a local-directory no-op on update.\nGot: {stdout}"
+    );
+    ensure!(
+        is_symlink(&schemes_repo_path(&data_path))?,
+        "The schemes symlink should still be in place after update."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn schemes_source_switch_reconciles_slot_kind() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_switch_slot_kind", "install", false)?;
+    let schemes = schemes_repo_path(&data_path);
+
+    let local_schemes = temp.path().join("local-schemes");
+    write_scheme(&local_schemes, "sw-local", "Switch Local")?;
+    let remote = temp.path().join("custom-schemes");
+    init_scheme_repo(&remote, "sw-remote", "Switch Remote")?;
+
+    let local_cfg = format!(
+        "[schemes]\npath = \"{}\"\n\n{}",
+        local_schemes.display(),
+        local_item_config(temp.path())?
+    );
+    let url_cfg = format!(
+        "[schemes]\npath = \"{}\"\n\n{}",
+        file_url(&remote),
+        local_item_config(temp.path())?
+    );
+
+    // Local path => symlink.
+    write_to_file(&config_path, &local_cfg)?;
+    run_command(&command_vec)?;
+    ensure!(
+        is_symlink(&schemes)?,
+        "expected a symlink after a local-path install"
+    );
+
+    // Switch to a Git URL => the symlink is replaced by a clone.
+    write_to_file(&config_path, &url_cfg)?;
+    run_command(&command_vec)?;
+    ensure!(
+        !is_symlink(&schemes)? && schemes.join(".git").exists(),
+        "expected a clone after switching to a URL source"
+    );
+
+    // Switch back to a local path => the clone is replaced by a symlink.
+    write_to_file(&config_path, &local_cfg)?;
+    run_command(&command_vec)?;
+    ensure!(
+        is_symlink(&schemes)?,
+        "expected a symlink after switching back to a local path"
+    );
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Circular reference
+// -----------------------------------------------------------------------------
+
+#[test]
+fn schemes_circular_reference_is_rejected() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_circular_reference", "install", false)?;
+
+    // Pre-create the managed schemes slot so it passes the "existing directory"
+    // config validation and reaches the circular-reference check.
+    let schemes = schemes_repo_path(&data_path);
+    fs::create_dir_all(&schemes)?;
+
+    let config = format!(
+        "[schemes]\npath = \"{}\"\n\n{}",
+        schemes.display(),
+        local_item_config(temp.path())?
+    );
+    write_to_file(&config_path, &config)?;
+
+    let (_stdout, stderr) = run_command(&command_vec)?;
+    ensure!(
+        stderr.contains("circular reference"),
+        "Pointing [schemes].path at the managed schemes dir must be rejected.\nGot: {stderr}"
+    );
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Backwards compatibility
+// -----------------------------------------------------------------------------
+
+#[test]
+fn default_schemes_repo_is_backwards_compatible() -> Result<()> {
+    // `cache: true` seeds the real schemes repo from the shared cache.
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_default_backwards_compat", "install", true)?;
+
+    // A local item avoids a network clone of the default tinted-shell item.
+    write_to_file(&config_path, &local_item_config(temp.path())?)?;
+
+    run_command(&command_vec)?;
+
+    let schemes = schemes_repo_path(&data_path);
+    ensure!(
+        !is_symlink(&schemes)?,
+        "The default schemes repo must be a clone, not a symlink."
+    );
+
+    // The built-in schemes are listable.
+    let list_vec = build_command_vec("list", &config_path, &data_path)?;
+    let (stdout, _) = run_command(&list_vec)?;
+    ensure!(
+        stdout.contains("base16-"),
+        "Expected built-in base16 schemes to be listed.\nGot: {}",
+        stdout.lines().take(3).collect::<Vec<_>>().join(", ")
+    );
+
+    Ok(())
+}

--- a/tests/cli_schemes_repo_tests.rs
+++ b/tests/cli_schemes_repo_tests.rs
@@ -300,6 +300,62 @@ fn schemes_local_path_update_is_noop() -> Result<()> {
 }
 
 #[test]
+fn schemes_url_change_reclones_on_install_but_unchanged_url_is_noop() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("schemes_url_change_reclones", "install", false)?;
+    let schemes = schemes_repo_path(&data_path);
+
+    let remote_a = temp.path().join("schemes-a");
+    init_scheme_repo(&remote_a, "scheme-a", "Scheme A")?;
+    let remote_b = temp.path().join("schemes-b");
+    init_scheme_repo(&remote_b, "scheme-b", "Scheme B")?;
+
+    let cfg_a = format!(
+        "[schemes]\npath = \"{}\"\n\n{}",
+        file_url(&remote_a),
+        local_item_config(temp.path())?
+    );
+    let cfg_b = format!(
+        "[schemes]\npath = \"{}\"\n\n{}",
+        file_url(&remote_b),
+        local_item_config(temp.path())?
+    );
+
+    // Install from A.
+    write_to_file(&config_path, &cfg_a)?;
+    run_command(&command_vec)?;
+    ensure!(
+        schemes.join("base16").join("scheme-a.yaml").exists(),
+        "expected repo A's scheme after the first install"
+    );
+
+    // Re-installing with the SAME URL must not re-clone: a local untracked file
+    // in the clone survives.
+    let sentinel = schemes.join("sentinel.txt");
+    write_to_file(&sentinel, "keep me\n")?;
+    run_command(&command_vec)?;
+    ensure!(
+        sentinel.exists(),
+        "an unchanged URL should be a no-op, not a destructive re-clone"
+    );
+
+    // Point the source at a different URL (repo B) and re-install: the clone is
+    // replaced so it reflects the new source.
+    write_to_file(&config_path, &cfg_b)?;
+    run_command(&command_vec)?;
+    ensure!(
+        schemes.join("base16").join("scheme-b.yaml").exists(),
+        "install should re-clone from the newly-configured URL"
+    );
+    ensure!(
+        !schemes.join("base16").join("scheme-a.yaml").exists(),
+        "the previous repo's content should be gone after switching URLs"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn schemes_source_switch_reconciles_slot_kind() -> Result<()> {
     let (config_path, data_path, command_vec, temp) =
         setup("schemes_switch_slot_kind", "install", false)?;


### PR DESCRIPTION
Follows #181 (now merged into `main`). Extends the `[schemes]` config table with `path` and `revision`, letting the built-in schemes repository be pointed at an alternate source and/or pinned to a different Git revision.

## Fields

- **`[schemes].path`** — a Git remote URL (cloned into `repos/schemes`) or a local directory (symlinked as `repos/schemes`, and not required to be a Git repo). Follows the same rules as an item's `path`, including `~/` expansion.
- **`[schemes].revision`** — a branch, tag, or commit SHA, resolved exactly like an `[[items]]` revision. Ignored for local-path sources.

Either key may be set on its own: `revision` alone re-pins the built-in repo; `path` alone swaps the source and defaults the revision.

## Behavior

- **Backwards-compatible.** With neither key set, the built-in `tinted-theming/schemes` repo at its pinned revision is used, exactly as before.
- **Same install/update semantics as `[[items]]`** — URL sources reuse the item clone/`update`/`allow-dirty-update` logic; local paths symlink and are a no-op on `update`.
- The `repos/schemes` slot is reconciled between clone and symlink when the source type changes.
- Pointing `path` at tinty's own managed `repos/schemes` directory is rejected as a circular reference.

## Tests

New `tests/cli_schemes_repo_tests.rs` (fully offline via `file://` remotes and local dirs): URL clone, revision checkout, local symlink with ignored revision, update-pull from a URL source, local-path update no-op, clone↔symlink slot switching, circular-reference rejection, and default backwards-compat. Plus unit tests in `config.rs`.

_Authored with AI assistance._