### PR TITLE
fix(update): leave local-path items untouched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
   repo locally. Non-overlapping local changes are carried forward; an update
   that would overwrite uncommitted work (or an untracked file) is refused and
   leaves the working tree untouched. Set it per `[[items]]` entry, or under the
-  `[schemes]` table for the built-in schemes repo.
+  `[schemes]` table for the built-in schemes repo. Local-path items (a `path`
+  pointing at a directory rather than a Git URL) are symlinks into directories
+  you manage yourself, so `tinty update` leaves them as-is and never fetches,
+  checks out, or rewrites their `origin`.
 - Add `[schemes].path` and `[schemes].revision` config options to override the
   source of the built-in schemes repository. `path` accepts an HTTPS Git URL
   (cloned into `repos/schemes`) or a local directory (symlinked as

--- a/README.md
+++ b/README.md
@@ -336,6 +336,12 @@ This option is per-item. The built-in schemes repository has no `[[items]]`
 entry of its own, so its equivalent setting lives under the
 [`[schemes]` table](#schemes-table-configtoml-schema).
 
+`allow-dirty-update` only applies to items whose `path` is a Git URL. An item
+whose `path` points at a local directory is symlinked into place and is a
+directory you manage yourself, so `tinty update` always leaves it untouched —
+it never fetches, checks out, or rewrites its `origin`, regardless of this
+setting.
+
 #### Note on `supported-systems`
 
 The `supported-systems` key within an `[[items]]` table allows for specifying

--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -59,6 +59,23 @@ fn print_conflict_message(item_name: &str, git_stderr: &str) {
     }
 }
 
+/// Reports the state of a local-path dependency without touching it. A local
+/// path is a live symlink into a directory the user manages themselves, so
+/// there is no remote to fetch and no revision to check out — `update` must
+/// leave it entirely alone (running git against it would reset the user's HEAD
+/// and rewrite their `origin`). We only confirm the symlink is still in place,
+/// exactly what `install` guarantees.
+fn report_local_dir(name: &str, repo_path: &Path, is_quiet: bool) {
+    if is_quiet {
+        return;
+    }
+    if repo_path.exists() {
+        println!("{name} — left as-is (local path, no remote to update)");
+    } else {
+        println!("{name} not installed (run `{REPO_NAME} install`)");
+    }
+}
+
 /// Updates the built-in schemes repository from its configured source.
 ///
 /// A Git URL source is pulled to its revision exactly like an item. A local-path
@@ -81,13 +98,7 @@ fn update_schemes_repo(
             is_quiet,
         )
     } else {
-        if !is_quiet {
-            if schemes_repo_path.exists() {
-                println!("{SCHEMES_REPO_NAME} up to date (local directory)");
-            } else {
-                println!("{SCHEMES_REPO_NAME} not installed (run `{REPO_NAME} install`)");
-            }
-        }
+        report_local_dir(SCHEMES_REPO_NAME, schemes_repo_path, is_quiet);
         Ok(())
     }
 }
@@ -107,14 +118,22 @@ pub fn update(config_path: &Path, data_path: &Path, is_quiet: bool) -> Result<()
     for item in items {
         let item_path = hooks_path.join(&item.name);
 
-        update_item(
-            item.name.as_str(),
-            item.path.as_str(),
-            &item_path,
-            item.revision.as_deref(),
-            item.allow_dirty_update,
-            is_quiet,
-        )?;
+        // A local-path item is a symlink into a directory the user owns and
+        // edits directly (its own branches, its own `origin`). There is nothing
+        // to fetch or check out, so mirror `install`'s URL-vs-path dispatch and
+        // leave it untouched rather than running git against the user's tree.
+        if Url::parse(item.path.as_str()).is_ok() {
+            update_item(
+                item.name.as_str(),
+                item.path.as_str(),
+                &item_path,
+                item.revision.as_deref(),
+                item.allow_dirty_update,
+                is_quiet,
+            )?;
+        } else {
+            report_local_dir(item.name.as_str(), &item_path, is_quiet);
+        }
     }
 
     let schemes_repo_path = hooks_path.join(SCHEMES_REPO_NAME);

--- a/tests/cli_schemes_repo_tests.rs
+++ b/tests/cli_schemes_repo_tests.rs
@@ -288,7 +288,7 @@ fn schemes_local_path_update_is_noop() -> Result<()> {
     let update_vec = build_command_vec("update", &config_path, &data_path)?;
     let (stdout, _) = run_command(&update_vec)?;
     ensure!(
-        stdout.contains("schemes up to date (local directory)"),
+        stdout.contains("schemes — left as-is (local path, no remote to update)"),
         "A local-path schemes source should report a local-directory no-op on update.\nGot: {stdout}"
     );
     ensure!(

--- a/tests/cli_update_allow_dirty_tests.rs
+++ b/tests/cli_update_allow_dirty_tests.rs
@@ -90,9 +90,13 @@ fn fixture(name: &str) -> Result<Fixture> {
 }
 
 /// `[[items]]` config for the fixture, optionally setting the per-item flag.
+///
+/// The remote is addressed as a `file://` URL so tinty treats the item as a Git
+/// remote to fetch (a bare local path would be treated as a symlinked local
+/// directory and left untouched — see `update_leaves_local_path_item_untouched`).
 fn item_config(remote: &Path, item_allow: Option<bool>) -> String {
     let mut config = format!(
-        "[[items]]\npath = \"{}\"\nname = \"{ITEM_NAME}\"\nthemes-dir = \".\"\n",
+        "[[items]]\npath = \"file://{}\"\nname = \"{ITEM_NAME}\"\nthemes-dir = \".\"\n",
         remote.display()
     );
     if let Some(value) = item_allow {
@@ -342,6 +346,75 @@ fn conflict_is_detected_regardless_of_git_locale() -> Result<()> {
     ensure!(
         head(&f.clone)? == before,
         "HEAD must not move when the update is refused."
+    );
+
+    Ok(())
+}
+
+/// A local-path item is a symlink into a directory the user manages directly.
+/// `update` must leave it completely alone — never fetch, check out, or rewrite
+/// its `origin` — even with `allow-dirty-update = true`. (Regression: the flag
+/// used to let `update` run git against the user's working tree, resetting HEAD
+/// and clobbering `origin` to the item's own path.)
+#[test]
+fn update_leaves_local_path_item_untouched() -> Result<()> {
+    let (config_path, data_path, command_vec, temp) =
+        setup("allow_dirty_local_path", "update", false)?;
+
+    // A directory the user owns: its own repo, its own `origin`, its own branch.
+    let live = temp.path().join("live");
+    fs::create_dir_all(&live)?;
+    git(&live, &["init", "-q", "-b", "main"])?;
+    git(&live, &["config", "user.email", "tinty@test.local"])?;
+    git(&live, &["config", "user.name", "tinty test"])?;
+    let sentinel_origin = "https://github.com/tinted-theming/tinted-terminal";
+    git(&live, &["remote", "add", "origin", sentinel_origin])?;
+    fs::write(live.join("theme-a.txt"), "a1\n")?;
+    git(&live, &["add", "-A"])?;
+    git(&live, &["commit", "-q", "-m", "init"])?;
+    let head_before = head(&live)?;
+
+    // `tinty build .` dirties tracked artifacts and drops untracked files.
+    fs::write(live.join("theme-a.txt"), "my local build\n")?;
+    fs::write(live.join("tinted8-new.txt"), "new\n")?;
+
+    // `install` symlinks a local-path item into repos/<name>; emulate that.
+    let repo_slot = data_path.join("repos").join(ITEM_NAME);
+    fs::create_dir_all(repo_slot.parent().unwrap())?;
+    std::os::unix::fs::symlink(&live, &repo_slot)?;
+
+    // A local-path item (NOT a URL) with allow-dirty on, to prove the flag does
+    // not cause git to run against the user's directory.
+    let config = format!(
+        "[[items]]\npath = \"{}\"\nname = \"{ITEM_NAME}\"\nthemes-dir = \".\"\nallow-dirty-update = true\n",
+        live.display()
+    );
+    write_to_file(&config_path, &config)?;
+
+    let (stdout, _) = run_update(&command_vec)?;
+
+    ensure!(
+        stdout.contains(&format!(
+            "{ITEM_NAME} — left as-is (local path, no remote to update)"
+        )),
+        "Expected a local-directory no-op message.\nGot: {stdout}"
+    );
+    // The regression guards: git must not have touched the user's repo.
+    ensure!(
+        git(&live, &["config", "--get", "remote.origin.url"])?.trim() == sentinel_origin,
+        "origin must not be clobbered for a local-path item."
+    );
+    ensure!(
+        head(&live)? == head_before,
+        "HEAD must not move for a local-path item."
+    );
+    ensure!(
+        fs::read_to_string(live.join("theme-a.txt"))? == "my local build\n",
+        "Local uncommitted edits must be preserved."
+    );
+    ensure!(
+        live.join("tinted8-new.txt").exists(),
+        "Untracked files must be preserved."
     );
 
     Ok(())


### PR DESCRIPTION
`tinty update` ran its full git machinery against every `[[items]]` entry, including local-path items — which `install` symlinks into `repos/<name>` rather than cloning. Before `allow-dirty-update`, the dirty-tree skip masked this: a local checkout under active development is almost always dirty, so update never reached the git calls. Turning on `allow-dirty-update` exposed it, and update would reset the user's HEAD and rewrite the `origin` of a directory they manage themselves (clobbering it to the item's own path).

`update` now mirrors `install`'s URL-vs-path dispatch: a local-path item is left as-is and never fetched or checked out. This fixes `tinty sync` too, since it chains install then update.
