### PR TITLE
Add TINTY_THEME_REPO_ROOT environment variable for hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ to your preferences and environment.
 |---------------|-------------|
 | `TINTY_THEME_FILE_PATH` | Path to the theme file for that `[[items]]` entry<br>e.g. `/home/user/.local/share/tinted-theming/tinty/tinted-alacritty-colors-file.toml` |
 | `TINTY_THEME_OPERATION` | The command operation that is running the hook e.g. `apply` or `init`  |
+| `TINTY_REPO_PATH` | Path to the root of the template repository for that `[[items]]` entry<br>e.g. `/home/user/.local/share/tinted-theming/tinty/repos/tinted-terminal` |
 | `TINTY_SCHEME_ID` | The unique name of the applied theme e.g. `base16-ayu-dark` |
 | `TINTY_SCHEME_SYSTEM` | The system-part of the theme ID e.g. `base16` or `base24` |
 | `TINTY_SCHEME_SLUG` | The slug-part of the theme ID e.g. `ayu-dark` |

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -184,6 +184,7 @@ pub fn apply(
                         command_template: hook_text.clone(),
                         operation: active_operation.unwrap_or("apply").to_string(),
                         relative_file_path: PathBuf::from(filename),
+                        repo_path: repo_path.clone(),
                     };
                     hook_commands.push(hook_parts);
                 }
@@ -329,6 +330,7 @@ struct Hook {
     command_template: String,
     operation: String,
     relative_file_path: PathBuf,
+    repo_path: PathBuf,
 }
 
 impl Hook {
@@ -359,6 +361,7 @@ impl Hook {
             .args(args)
             .env("TINTY_THEME_FILE_PATH", theme_file_path)
             .env("TINTY_THEME_OPERATION", self.operation.as_str())
+            .env("TINTY_REPO_PATH", self.repo_path.display().to_string())
             .envs(SchemeEntry::from_scheme(&scheme_file.get_scheme()?).to_envs())
             .spawn()
             .with_context(|| {


### PR DESCRIPTION
This PR adds the `TINTY_REPO_PATH` environment variable to hooks, exposing the template repository's root path during hook execution.

This feature was developed while investigating [tinted-theming/tinted-terminal#37](https://github.com/tinted-theming/tinted-terminal/issues/37) to allow Konsole theme switching (and specifically `konsoleprofile` tmux passthrough) to call helper scripts shipped inside template repositories without hardcoding absolute paths. Even though we haven't heard back from the issue reporter yet, exposing `TINTY_REPO_PATH` is generally useful for any template hooks that need to execute repo-provided scripts.